### PR TITLE
Analytics query builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+*.iml
+.idea/

--- a/phc/web/subject_search.py
+++ b/phc/web/subject_search.py
@@ -1,0 +1,49 @@
+
+class SubjectSearchComponent(object):
+
+    def __init__(self):
+        self.component_body = dict()
+
+    def __getattr__(self, attr):
+        handler = self.__global_handler
+        handler.__func__.func_name = attr
+        return handler
+
+    def __global_handler(self, *args, **kwargs):
+        self.component_body[self.__global_handler.__func__.func_name] = kwargs
+        return
+
+    def to_dict(self):
+        return self.component_body
+
+
+class SubjectSearchComponents(object):
+
+    def __init__(self):
+        self.key_components = dict()
+
+    def observations(self):
+        search_component = SubjectSearchComponent()
+        if 'observations' not in self.key_components:
+            self.key_components['observations'] = []
+        self.key_components['observations'].append(search_component)
+        return search_component
+
+    def to_dict(self):
+        key_components_dict = dict()
+        for key, components in self.key_components.items():
+            components_dict = []
+            for component in components:
+                components_dict.append(component.to_dict())
+            key_components_dict[key] = components_dict
+        return key_components_dict
+
+
+class SubjectSearch(object):
+
+    def __init__(self, client):
+        self.client = client
+        self.search_components = dict()
+
+    def patient(self, search_components):
+        self.search_components['patient'] = search_components.to_dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aiohttp>3.5.2
+aiohttp>3.5.3

--- a/tests/unit/tests.py
+++ b/tests/unit/tests.py
@@ -1,0 +1,14 @@
+import unittest
+
+from phc.web.subject_search import SubjectSearch, SubjectSearchComponents
+
+
+class SubjectSearchTest(unittest.TestCase):
+
+    def test_subject_search(self):
+        search = SubjectSearchComponents()
+        search.observations()\
+            .value_codeable_concept(eq=['LA10316-0', 'LA10315-2'])
+
+        expected = {'observations': [{'value_codeable_concept': {'eq': ['LA10316-0', 'LA10315-2']}}]}
+        self.assertDictEqual(search.to_dict(), expected)


### PR DESCRIPTION
Initial pass for analytics query builder.
```
search = SubjectSearchComponents()
search.observations()\
    .value_codeable_concept(eq=['LA10316-0', 'LA10315-2'])

expected = {'observations': [{'value_codeable_concept': {'eq': ['LA10316-0', 'LA10315-2']}}]}
self.assertDictEqual(search.to_dict(), expected)
```

I'm hooking it to Mark's base_client next.