### PR TITLE
Changes pip3 to pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make lint
 ### Installation
 
 ```bash
-pip3 install phc
+pip install phc
 ```
 
 ### Usage


### PR DESCRIPTION
Since Python 3 is the standard now, users shouldn't be using pip3 any longer.