### PR TITLE
Fix empty columns being created when frame is expanded

### DIFF
--- a/phc/easy/codeable.py
+++ b/phc/easy/codeable.py
@@ -1,4 +1,5 @@
 import os
+import math
 import re
 import pandas as pd
 from functools import reduce
@@ -101,19 +102,21 @@ def flatten_and_find_prefix(codeable_dict, prefix):
 
 def generic_codeable_to_dict(codeable, prefix=""):
     "Convert dict/list/str contains code data to a flat dictionary"
+    if isinstance(codeable, float) and math.isnan(codeable):
+        return {}
 
-    if type(codeable) == list:
+    if isinstance(codeable, list):
         return concat_dicts(
             [generic_codeable_to_dict(d, prefix) for d in codeable]
         )
 
-    if type(codeable) != dict:
+    if not isinstance(codeable, dict):
         return {prefix: codeable}
 
     codeable, prefix = flatten_and_find_prefix(codeable, prefix)
 
     # Recurse pre-processed value is not a dictionary (but a list for example)
-    if type(codeable) != dict:
+    if not isinstance(codeable, dict):
         return generic_codeable_to_dict(codeable, prefix)
 
     def prefixer(dictionary):

--- a/phc/easy/frame.py
+++ b/phc/easy/frame.py
@@ -1,8 +1,16 @@
-import pandas as pd
 from typing import Callable, List, Tuple
+import pandas as pd
 from phc.easy.codeable import Codeable
 
-CODE_COLUMNS = ["meta", "identifier", "extension", "telecom"]
+CODE_COLUMNS = [
+    "meta",
+    "identifier",
+    "extension",
+    "telecom",
+    "valueCodeableConcept",
+    "code",
+    "valueQuantity",
+]
 DATE_COLUMNS = ["dob", "birth_date", "birthDate", "deceasedDateTime"]
 
 
@@ -60,17 +68,16 @@ class Frame:
             key for key, _func in custom_columns if key in frame.columns
         ]
 
-        combined = pd.concat(
-            [
-                *[
-                    column_to_frame(frame, key, func)
-                    for key, func in custom_columns
-                ],
-                frame.drop([*codeable_col_names, *custom_names], axis=1),
-                *code_frames,
+        columns = [
+            *[
+                column_to_frame(frame, key, func)
+                for key, func in custom_columns
             ],
-            axis=1,
-        )
+            frame.drop([*codeable_col_names, *custom_names], axis=1),
+            *code_frames,
+        ]
+
+        combined = pd.concat(columns, axis=1)
 
         # Mutate data frame to parse date columns
         for column_key in all_date_columns:

--- a/tests/test_codeable.py
+++ b/tests/test_codeable.py
@@ -1,132 +1,151 @@
-from phc.easy.codeable import generic_codeable_to_dict
+import pandas as pd
+import math
+from phc.easy.codeable import generic_codeable_to_dict, Codeable
+
 
 def test_parsing_lat_long_extension():
     expected = {
-        'hl7_org_fhir_StructureDefinition_geolocation__latitude__valueDecimal':
-        -71.058706,
-        'hl7_org_fhir_StructureDefinition_geolocation__longitude__valueDecimal':
-        42.42938
+        "hl7_org_fhir_StructureDefinition_geolocation__latitude__valueDecimal": -71.058706,
+        "hl7_org_fhir_StructureDefinition_geolocation__longitude__valueDecimal": 42.42938,
     }
 
-    assert generic_codeable_to_dict({
-        'url':
-        'http://hl7.org/fhir/StructureDefinition/geolocation',
-        'extension': [{
-            'url': 'latitude',
-            'valueDecimal': -71.058706
-        }, {
-            'url': 'longitude',
-            'valueDecimal': 42.42938
-        }]
-    }) == expected
+    assert (
+        generic_codeable_to_dict(
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/geolocation",
+                "extension": [
+                    {"url": "latitude", "valueDecimal": -71.058706},
+                    {"url": "longitude", "valueDecimal": 42.42938},
+                ],
+            }
+        )
+        == expected
+    )
 
 
 def test_parsing_simple_meta_value():
     input_dict = {
-        'tag': [{
-            'system': 'http://lifeomic.com/fhir/group',
-            'code': 'group-code-id'
-        }, {
-            'system': 'http://lifeomic.com/fhir/dataset',
-            'code': 'dataset-code-id'
-        }, {
-            'system': 'http://lifeomic.com/fhir/dataset',
-            'code': 'dataset-second-code-id'
-        }, {
-            'system': 'http://lifeomic.com/fhir/source',
-            'code': 'LifeOmic Consent'
-        }, {
-            'system': 'http://lifeomic.com/fhir/questionnaire-type',
-            'code': 'consent-form'
-        }],
-        'lastUpdated':
-        '2019-08-13T17:47:18.957Z'
+        "tag": [
+            {
+                "system": "http://lifeomic.com/fhir/group",
+                "code": "group-code-id",
+            },
+            {
+                "system": "http://lifeomic.com/fhir/dataset",
+                "code": "dataset-code-id",
+            },
+            {
+                "system": "http://lifeomic.com/fhir/dataset",
+                "code": "dataset-second-code-id",
+            },
+            {
+                "system": "http://lifeomic.com/fhir/source",
+                "code": "LifeOmic Consent",
+            },
+            {
+                "system": "http://lifeomic.com/fhir/questionnaire-type",
+                "code": "consent-form",
+            },
+        ],
+        "lastUpdated": "2019-08-13T17:47:18.957Z",
     }
 
     assert generic_codeable_to_dict(input_dict) == {
-        'tag_lastUpdated': '2019-08-13T17:47:18.957Z',
-        'tag_lifeomic_com_fhir_group__code': 'group-code-id',
-        'tag_lifeomic_com_fhir_dataset__code': 'dataset-code-id',
-        'tag_lifeomic_com_fhir_dataset__code_1': 'dataset-second-code-id',
-        'tag_lifeomic_com_fhir_source__code': 'LifeOmic Consent',
-        'tag_lifeomic_com_fhir_questionnaire-type__code': 'consent-form'
+        "tag_lastUpdated": "2019-08-13T17:47:18.957Z",
+        "tag_lifeomic_com_fhir_group__code": "group-code-id",
+        "tag_lifeomic_com_fhir_dataset__code": "dataset-code-id",
+        "tag_lifeomic_com_fhir_dataset__code_1": "dataset-second-code-id",
+        "tag_lifeomic_com_fhir_source__code": "LifeOmic Consent",
+        "tag_lifeomic_com_fhir_questionnaire-type__code": "consent-form",
     }
 
 
 def test_parsing_system_value():
     assert generic_codeable_to_dict(
         {
-            'system': 'http://lifeomic.com/fhir/consent-form-id',
-            'value': 'default-project-consent-form'
+            "system": "http://lifeomic.com/fhir/consent-form-id",
+            "value": "default-project-consent-form",
         },
-        prefix='extension') == {
-            'extension_lifeomic_com_fhir_consent-form-id__value':
-            'default-project-consent-form'
-        }
+        prefix="extension",
+    ) == {
+        "extension_lifeomic_com_fhir_consent-form-id__value": "default-project-consent-form"
+    }
 
 
 def test_parsing_extension_with_race():
-    input_dict = [{
-        'url': 'http://hl7.org/fhir/StructureDefinition/us-core-race',
-        'valueCodeableConcept': {
-            'text':
-            'race',
-            'coding': [{
-                'code': '2106-3',
-                'system': 'http://hl7.org/fhir/v3/Race',
-                'display': 'white'
-            }]
-        }
-    }, {
-        'url': 'http://hl7.org/fhir/StructureDefinition/us-core-ethnicity',
-        'valueCodeableConcept': {
-            'text':
-            'ethnicity',
-            'coding': [{
-                'code': '2186-5',
-                'system': 'http://hl7.org/fhir/v3/Ethnicity',
-                'display': 'not hispanic or latino'
-            }]
-        }
-    }]
+    input_dict = [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
+            "valueCodeableConcept": {
+                "text": "race",
+                "coding": [
+                    {
+                        "code": "2106-3",
+                        "system": "http://hl7.org/fhir/v3/Race",
+                        "display": "white",
+                    }
+                ],
+            },
+        },
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/us-core-ethnicity",
+            "valueCodeableConcept": {
+                "text": "ethnicity",
+                "coding": [
+                    {
+                        "code": "2186-5",
+                        "system": "http://hl7.org/fhir/v3/Ethnicity",
+                        "display": "not hispanic or latino",
+                    }
+                ],
+            },
+        },
+    ]
 
     assert generic_codeable_to_dict(input_dict) == {
-        'hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__text':
-        'race',
-        'hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__code':
-        '2106-3',
-        'hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__display':
-        'white',
-        'hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__text':
-        'ethnicity',
-        'hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__code':
-        '2186-5',
-        'hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__display':
-        'not hispanic or latino',
+        "hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__text": "race",
+        "hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__code": "2106-3",
+        "hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__display": "white",
+        "hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__text": "ethnicity",
+        "hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__code": "2186-5",
+        "hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__display": "not hispanic or latino",
     }
 
 
 def test_parsing_anonymous_identifier():
-    input_dict = [{
-        'type': {
-            'coding': [{
-                'code': 'ANON',
-                'system': 'http://hl7.org/fhir/v2/0203'
-            }]
-        },
-        'value': 'LO-AR-A251'
-    }]
+    input_dict = [
+        {
+            "type": {
+                "coding": [
+                    {"code": "ANON", "system": "http://hl7.org/fhir/v2/0203"}
+                ]
+            },
+            "value": "LO-AR-A251",
+        }
+    ]
 
     assert generic_codeable_to_dict(input_dict) == {
-        'hl7_org_fhir_v2_0203__code': 'ANON',
-        'hl7_org_fhir_v2_0203__value': 'LO-AR-A251'
+        "hl7_org_fhir_v2_0203__code": "ANON",
+        "hl7_org_fhir_v2_0203__value": "LO-AR-A251",
     }
 
 
 def test_parsing_basic_meta_value():
-    input_dict = {'tag': [{'system': 'http://lifeomic.com/fhir/dataset',
-        'code': 'dataset-code'}]}
+    input_dict = {
+        "tag": [
+            {
+                "system": "http://lifeomic.com/fhir/dataset",
+                "code": "dataset-code",
+            }
+        ]
+    }
 
     assert generic_codeable_to_dict(input_dict) == {
-        'tag_lifeomic_com_fhir_dataset__code': 'dataset-code'
+        "tag_lifeomic_com_fhir_dataset__code": "dataset-code"
     }
+
+
+def test_not_creating_extraneous_columns():
+    frame = pd.DataFrame([{"a": "value"}, {"b": math.nan}])
+
+    assert len(Codeable.expand_column(frame.b).columns) == 0


### PR DESCRIPTION
When working on pulling down observations, I found that empty columns were getting created when the frame is expanded. This PR resolves that.