### PR TITLE
Add phc.easy.Observations class

### DIFF
--- a/phc/easy/__init__.py
+++ b/phc/easy/__init__.py
@@ -4,5 +4,14 @@ from phc.easy.patients import Patient
 from phc.easy.projects import Project
 from phc.easy.auth import Auth
 from phc.easy.codeable import Codeable
+from phc.easy.observation import Observation
 
-__all__ = ['Frame', 'Query', 'Patient', 'Auth', 'Codeable', 'Project']
+__all__ = [
+    "Frame",
+    "Query",
+    "Patient",
+    "Auth",
+    "Codeable",
+    "Project",
+    "Observation",
+]

--- a/phc/easy/__init__.py
+++ b/phc/easy/__init__.py
@@ -5,6 +5,8 @@ from phc.easy.projects import Project
 from phc.easy.auth import Auth
 from phc.easy.codeable import Codeable
 from phc.easy.observation import Observation
+from phc.easy.procedure import Procedure
+from phc.easy.patient_item import PatientItem
 
 __all__ = [
     "Frame",
@@ -14,4 +16,6 @@ __all__ = [
     "Codeable",
     "Project",
     "Observation",
+    "PatientItem",
+    "Procedure",
 ]

--- a/phc/easy/frame.py
+++ b/phc/easy/frame.py
@@ -32,6 +32,15 @@ def column_to_frame(frame: pd.DataFrame, column_name: str, expand_func):
 
 class Frame:
     @staticmethod
+    def codeable_like_column_expander(column_name: str):
+        """Codeable expansion with prefix for passing to Frame.expand#custom_columns"""
+
+        def _expander(column):
+            return Codeable.expand_column(column).add_prefix(f"{column_name}.")
+
+        return (column_name, _expander)
+
+    @staticmethod
     def expand(
         frame: pd.DataFrame,
         code_columns: List[str] = [],
@@ -40,7 +49,8 @@ class Frame:
             Tuple[str, Callable[[pd.Series], pd.DataFrame]]
         ] = [],
     ):
-        """Expand a data frame with FHIR codes, nested JSON structures, etc into a full, tabular data frame that can much more easily be wrangled
+        """Expand a data frame with FHIR codes, nested JSON structures, etc into a full,
+        tabular data frame that can much more easily be wrangled
 
         Attributes
         ----------
@@ -57,6 +67,7 @@ class Frame:
             A list of tuples with the column name and a function that expands a
             column to a data frame. This will get merged index-wise into the
             combined frame
+
         """
         all_code_columns = [*CODE_COLUMNS, *code_columns]
         all_date_columns = [*DATE_COLUMNS, *date_columns]

--- a/phc/easy/frame.py
+++ b/phc/easy/frame.py
@@ -10,8 +10,16 @@ CODE_COLUMNS = [
     "valueCodeableConcept",
     "code",
     "valueQuantity",
+    "category",
 ]
-DATE_COLUMNS = ["dob", "birth_date", "birthDate", "deceasedDateTime"]
+DATE_COLUMNS = [
+    "dob",
+    "birth_date",
+    "birthDate",
+    "deceasedDateTime",
+    "effectiveDateTime",
+    "tag_lastUpdated",
+]
 
 
 def column_to_frame(frame: pd.DataFrame, column_name: str, expand_func):

--- a/phc/easy/frame.py
+++ b/phc/easy/frame.py
@@ -68,7 +68,7 @@ class Frame:
         ]
 
         code_frames = [
-            Codeable.expand_column(frame[col_name])
+            Codeable.expand_column(frame[col_name]).add_prefix(f"{col_name}.")
             for col_name in codeable_col_names
         ]
 

--- a/phc/easy/observation.py
+++ b/phc/easy/observation.py
@@ -3,9 +3,22 @@ import pandas as pd
 from phc.easy.patient_item import PatientItem
 from phc.easy.frame import Frame
 from phc.easy.auth import Auth
+from phc.easy.query import Query
 
 
 class Observation:
+    @staticmethod
+    def get_count(query_overrides: dict = {}, auth_args=Auth.shared()):
+        return Query.find_count_of_dsl_query(
+            {
+                "type": "select",
+                "columns": "*",
+                "from": [{"table": "observation"}],
+                **query_overrides,
+            },
+            auth_args=auth_args,
+        )
+
     @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {

--- a/phc/easy/observation.py
+++ b/phc/easy/observation.py
@@ -1,0 +1,68 @@
+from typing import Union
+import pandas as pd
+from phc.easy.query import Query
+from phc.easy.frame import Frame
+from phc.easy.auth import Auth
+
+
+class Observation:
+    @staticmethod
+    def get_data_frame(
+        raw: bool = False,
+        patient_id: Union[None, str] = None,
+        auth_args=Auth.shared(),
+        expand_args: dict = {},
+    ):
+        """Retrieve observations
+
+        Attributes
+        ----------
+        raw : bool = False
+            If raw, then values will not be expanded (useful for manual
+            inspection if something goes wrong)
+
+        auth_args : Any
+            The authenication to use for the account and project (defaults to shared)
+
+        expand_args : Any
+            Additional arguments passed to phc.Frame.expand
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({'account': '<your-account-name>'})
+        >>> phc.Project.set_current('My Project Name')
+        >>> phc.Observation.get_data_frame(patient_id='<patient-id>')
+        """
+        query = {
+            "type": "select",
+            "columns": "*",
+            "from": [{"table": "observation"}],
+        }
+
+        if patient_id:
+            query = {
+                **query,
+                "where": {
+                    "type": "elasticsearch",
+                    "query": {
+                        "terms": {
+                            "subject.reference.keyword": [
+                                patient_id,
+                                f"Patient/{patient_id}",
+                            ]
+                        }
+                    },
+                },
+            }
+
+        results = Query.execute_dsl(
+            query, all_results=True, auth_args=auth_args
+        )
+
+        df = pd.DataFrame(map(lambda r: r["_source"], results))
+
+        if raw:
+            return df
+
+        return Frame.expand(df, **expand_args)

--- a/phc/easy/observation.py
+++ b/phc/easy/observation.py
@@ -8,8 +8,10 @@ from phc.easy.auth import Auth
 class Observation:
     @staticmethod
     def get_data_frame(
+        all_results: bool = False,
         raw: bool = False,
         patient_id: Union[None, str] = None,
+        query_overrides: dict = {},
         auth_args=Auth.shared(),
         expand_args: dict = {},
     ):
@@ -17,9 +19,15 @@ class Observation:
 
         Attributes
         ----------
+        all_results : bool = False
+            Retrieve sample of results (10) or entire set of observations
+
         raw : bool = False
             If raw, then values will not be expanded (useful for manual
             inspection if something goes wrong)
+
+        patient_id : None or str = None
+            Find observations for a given patient_id
 
         auth_args : Any
             The authenication to use for the account and project (defaults to shared)
@@ -56,9 +64,9 @@ class Observation:
                 },
             }
 
-        results = Query.execute_dsl(
-            query, all_results=True, auth_args=auth_args
-        )
+        query = {**query, **query_overrides}
+
+        results = Query.execute_dsl(query, all_results, auth_args)
 
         df = pd.DataFrame(map(lambda r: r["_source"], results))
 

--- a/phc/easy/observation.py
+++ b/phc/easy/observation.py
@@ -3,6 +3,14 @@ import pandas as pd
 from phc.easy.query import Query
 from phc.easy.frame import Frame
 from phc.easy.auth import Auth
+from phc.easy.codeable import Codeable
+
+
+def expander_for_codeable_like_column(prefix):
+    def _expander(column):
+        return Codeable.expand_column(column).add_prefix(prefix)
+
+    return _expander
 
 
 class Observation:
@@ -73,4 +81,14 @@ class Observation:
         if raw:
             return df
 
-        return Frame.expand(df, **expand_args)
+        args = {
+            **expand_args,
+            "custom_columns": [
+                *expand_args.get("custom_columns", []),
+                ("subject", expander_for_codeable_like_column("subject.")),
+                ("related", expander_for_codeable_like_column("related.")),
+                ("performer", expander_for_codeable_like_column("performer.")),
+            ],
+        }
+
+        return Frame.expand(df, **args)

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -1,0 +1,72 @@
+from typing import Union
+import pandas as pd
+from phc.easy.auth import Auth
+from phc.easy.query import Query
+
+
+class PatientItem:
+    @staticmethod
+    def retrieve_raw_data_frame(
+        table_name: str,
+        all_results: bool = False,
+        patient_id: Union[None, str] = None,
+        query_overrides: dict = {},
+        auth_args=Auth.shared(),
+    ):
+        """Retrieve results for a given table that relates to a patient
+
+        Attributes
+        ----------
+        table_name : str
+            The name of the elasticsearch FHIR table
+
+        all_results : bool = False
+            Retrieve sample of results (10) or entire set of the table records
+
+        patient_id : None or str = None
+            Find table records for a given patient_id
+
+        query_overrides : dict = {}
+            Override any part of the elasticsearch FHIR query
+
+        auth_args : Any
+            The authenication to use for the account and project (defaults to shared)
+
+        expand_args : Any
+            Additional arguments passed to phc.Frame.expand
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({'account': '<your-account-name>'})
+        >>> phc.Project.set_current('My Project Name')
+        >>> phc.PatientItem.retrieve_raw_data_frame("observation", patient_id='<patient-id>')
+        """
+
+        query = {
+            "type": "select",
+            "columns": "*",
+            "from": [{"table": table_name}],
+        }
+
+        if patient_id:
+            query = {
+                **query,
+                "where": {
+                    "type": "elasticsearch",
+                    "query": {
+                        "terms": {
+                            "subject.reference.keyword": [
+                                patient_id,
+                                f"Patient/{patient_id}",
+                            ]
+                        }
+                    },
+                },
+            }
+
+        query = {**query, **query_overrides}
+
+        results = Query.execute_dsl(query, all_results, auth_args)
+
+        return pd.DataFrame(map(lambda r: r["_source"], results))

--- a/phc/easy/patients/__init__.py
+++ b/phc/easy/patients/__init__.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 from phc.easy.auth import Auth
 from phc.easy.frame import Frame
@@ -10,7 +8,12 @@ from phc.services import Fhir
 
 class Patient:
     @staticmethod
-    def get_data_frame(limit: int, raw: bool = False, auth_args=Auth.shared()):
+    def get_data_frame(
+        limit: int,
+        raw: bool = False,
+        auth_args=Auth.shared(),
+        expand_args: dict = {},
+    ):
         """Retrieve all patients (up to limit) as a data frame with unwrapped FHIR columns
 
         Attributes
@@ -22,8 +25,11 @@ class Patient:
             If raw, then values will not be expanded (useful for manual
             inspection if something goes wrong)
 
-        auth : Auth
+        auth_args : Any
             The authenication to use for the account and project (defaults to shared)
+
+        expand_args : Any
+            Additional arguments passed to phc.Frame.expand
 
         Examples
         --------
@@ -51,10 +57,13 @@ class Patient:
         if raw:
             return df
 
-        return Frame.expand(
-            df,
-            custom_columns=[
+        args = {
+            **expand_args,
+            "custom_columns": [
+                *expand_args.get("custom_columns", []),
                 ("address", expand_address_column),
                 ("name", expand_name_column),
             ],
-        )
+        }
+
+        return Frame.expand(df, **args)

--- a/phc/easy/patients/__init__.py
+++ b/phc/easy/patients/__init__.py
@@ -9,6 +9,18 @@ from phc.easy.query import Query
 
 class Patient:
     @staticmethod
+    def get_count(query_overrides: dict = {}, auth_args=Auth.shared()):
+        return Query.find_count_of_dsl_query(
+            {
+                "type": "select",
+                "columns": "*",
+                "from": [{"table": "patient"}],
+                **query_overrides,
+            },
+            auth_args=auth_args,
+        )
+
+    @staticmethod
     def get_data_frame(
         limit: int = 100,
         all_results: bool = False,

--- a/phc/easy/procedure.py
+++ b/phc/easy/procedure.py
@@ -5,16 +5,20 @@ from phc.easy.frame import Frame
 from phc.easy.auth import Auth
 
 
-class Observation:
+class Procedure:
     @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {
             **expand_args,
+            "date_columns": [
+                *expand_args.get("date_columns", []),
+                "performedPeriod.start",
+                "performedPeriod.end",
+            ],
             "custom_columns": [
                 *expand_args.get("custom_columns", []),
                 Frame.codeable_like_column_expander("subject"),
-                Frame.codeable_like_column_expander("related"),
-                Frame.codeable_like_column_expander("performer"),
+                Frame.codeable_like_column_expander("performedPeriod"),
             ],
         }
 
@@ -29,19 +33,19 @@ class Observation:
         auth_args=Auth.shared(),
         expand_args: dict = {},
     ):
-        """Retrieve observations
+        """Retrieve procedures
 
         Attributes
         ----------
         all_results : bool = False
-            Retrieve sample of results (10) or entire set of observations
+            Retrieve sample of results (10) or entire set of procedures
 
         raw : bool = False
             If raw, then values will not be expanded (useful for manual
             inspection if something goes wrong)
 
         patient_id : None or str = None
-            Find observations for a given patient_id
+            Find procedures for a given patient_id
 
         query_overrides : dict = {}
             Override any part of the elasticsearch FHIR query
@@ -57,13 +61,13 @@ class Observation:
         >>> import phc.easy as phc
         >>> phc.Auth.set({'account': '<your-account-name>'})
         >>> phc.Project.set_current('My Project Name')
-        >>> phc.Observation.get_data_frame(patient_id='<patient-id>')
+        >>> phc.Procedure.get_data_frame(patient_id='<patient-id>')
         """
         data_frame = PatientItem.retrieve_raw_data_frame(
-            "observation", all_results, patient_id, query_overrides, auth_args
+            "procedure", all_results, patient_id, query_overrides, auth_args
         )
 
         if raw:
             return data_frame
 
-        return Observation.transform_results(data_frame, **expand_args)
+        return Procedure.transform_results(data_frame, **expand_args)

--- a/phc/easy/procedure.py
+++ b/phc/easy/procedure.py
@@ -3,9 +3,22 @@ import pandas as pd
 from phc.easy.patient_item import PatientItem
 from phc.easy.frame import Frame
 from phc.easy.auth import Auth
+from phc.easy.query import Query
 
 
 class Procedure:
+    @staticmethod
+    def get_count(query_overrides: dict = {}, auth_args=Auth.shared()):
+        return Query.find_count_of_dsl_query(
+            {
+                "type": "select",
+                "columns": "*",
+                "from": [{"table": "procedure"}],
+                **query_overrides,
+            },
+            auth_args=auth_args,
+        )
+
     @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {

--- a/phc/easy/query.py
+++ b/phc/easy/query.py
@@ -101,8 +101,8 @@ class Query:
         # Scroll if limit is above MAX_RESULT_SIZE
         limit = iter(query.get("limit", []))
 
-        lower = next(limit, {}).get("value")
-        upper = next(limit, {}).get("value")
+        lower = next(limit, {}).get("value", 0)
+        upper = next(limit, {}).get("value", 0)
 
         scroll = True if upper - lower > MAX_RESULT_SIZE else all_results
 

--- a/phc/easy/query.py
+++ b/phc/easy/query.py
@@ -83,6 +83,48 @@ def recursive_execute_dsl(
 
 class Query:
     @staticmethod
+    def find_count_of_dsl_query(query: dict, auth_args: Auth = Auth.shared()):
+        """Find count of a given dsl query
+
+        See https://docs.us.lifeomic.com/development/fhir-service/dsl/
+
+        Attributes
+        ----------
+        query : dict
+            The FHIR query to run a count against
+
+        auth_args : Auth, dict
+            Additional arguments for authentication
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({ 'account': '<your-account-name>' })
+        >>> phc.Project.set_current('My Project Name')
+        >>> phc.Query.find_count_of_dsl_query({
+          "type": "select",
+          "columns": "*",
+          "from": [{"table": "patient"}],
+        })
+        """
+        auth = Auth(auth_args)
+        fhir = Fhir(auth.session())
+
+        response = fhir.execute_es(
+            auth.project_id,
+            {
+                **query,
+                "limit": [
+                    {"type": "number", "value": 0},
+                    {"type": "number", "value": 1},
+                ],
+            },
+            scroll="true",
+        )
+
+        return response.data["hits"]["total"]["value"]
+
+    @staticmethod
     def execute_dsl(
         query: dict, all_results: bool = False, auth_args: Auth = Auth.shared(),
     ):

--- a/phc/easy/query.py
+++ b/phc/easy/query.py
@@ -35,7 +35,9 @@ def recursive_execute_dsl(
     results = [*_prev_hits, *current_results]
     _scroll_id = response.data.get("_scroll_id", "")
 
+    actual_count = response.data["hits"]["total"]["value"]
     if len(current_results) == 0 or scroll is False:
+        print(f"Retrieved {len(results)}/{actual_count} results")
         return results
 
     return recursive_execute_dsl(

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(exclude=("tests")),
     install_requires=requirements,
     include_package_data=True,
-    extras_require={"pandas": ["pandas"]},
+    extras_require={"pandas": ["pandas"], "tqdm": ["tqdm"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This new easy class pulls out observations and expands all of the relevant columns. It also performs paging as needed. I'm testing everything in PHC notebooks, but I'll work in the future on separating the API calls with the transforms so I can write more unit tests. 

Next up will be a progress indicator and/or file streaming in the Query class to enable our data-intensive research needs. I was able to successfully test this code with a set of +110K observations.