### PR TITLE
Add "streaming" FHIR results to file and auto-caching for easy modules

### DIFF
--- a/phc/easy/codeable.py
+++ b/phc/easy/codeable.py
@@ -1,15 +1,14 @@
-import os
 import math
 import re
-import pandas as pd
 from functools import reduce
-from phc import Session
-from phc.services import Fhir
+
+import pandas as pd
+
 from phc.easy.util import (
-    join_underscore,
-    without_keys,
     concat_dicts,
+    join_underscore,
     prefix_dict_keys,
+    without_keys,
 )
 
 

--- a/phc/easy/frame.py
+++ b/phc/easy/frame.py
@@ -20,7 +20,7 @@ DATE_COLUMNS = [
     "birthDate",
     "deceasedDateTime",
     "effectiveDateTime",
-    "tag_lastUpdated",
+    "meta.tag_lastUpdated",
 ]
 
 
@@ -103,6 +103,8 @@ class Frame:
         # Mutate data frame to parse date columns
         for column_key in all_date_columns:
             if column_key in combined.columns:
-                combined[column_key] = pd.to_datetime(combined[column_key])
+                combined[column_key] = pd.to_datetime(
+                    combined[column_key], utc=True
+                )
 
         return combined

--- a/phc/easy/frame.py
+++ b/phc/easy/frame.py
@@ -1,5 +1,7 @@
 from typing import Callable, List, Tuple
+
 import pandas as pd
+
 from phc.easy.codeable import Codeable
 
 CODE_COLUMNS = [

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -1,46 +1,20 @@
 from typing import Union
-import pandas as pd
-from phc.easy.auth import Auth
-from phc.easy.query import Query
 
 
 class PatientItem:
     @staticmethod
-    def retrieve_raw_data_frame(
-        table_name: str,
-        all_results: bool = False,
-        patient_id: Union[None, str] = None,
-        query_overrides: dict = {},
-        auth_args=Auth.shared(),
-    ):
-        """Retrieve results for a given table that relates to a patient
+    def build_query(
+        table_name: str, patient_id: Union[None, str] = None
+    ) -> dict:
+        """Build query for a given table that relates to a patient
 
         Attributes
         ----------
         table_name : str
             The name of the elasticsearch FHIR table
 
-        all_results : bool = False
-            Retrieve sample of results (10) or entire set of the table records
-
         patient_id : None or str = None
             Find table records for a given patient_id
-
-        query_overrides : dict = {}
-            Override any part of the elasticsearch FHIR query
-
-        auth_args : Any
-            The authenication to use for the account and project (defaults to shared)
-
-        expand_args : Any
-            Additional arguments passed to phc.Frame.expand
-
-        Examples
-        --------
-        >>> import phc.easy as phc
-        >>> phc.Auth.set({'account': '<your-account-name>'})
-        >>> phc.Project.set_current('My Project Name')
-        >>> phc.PatientItem.retrieve_raw_data_frame("observation", patient_id='<patient-id>')
         """
 
         query = {
@@ -50,7 +24,7 @@ class PatientItem:
         }
 
         if patient_id:
-            query = {
+            return {
                 **query,
                 "where": {
                     "type": "elasticsearch",
@@ -65,8 +39,4 @@ class PatientItem:
                 },
             }
 
-        query = {**query, **query_overrides}
-
-        results = Query.execute_fhir_dsl(query, all_results, auth_args)
-
-        return pd.DataFrame(map(lambda r: r["_source"], results))
+        return query

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -67,6 +67,6 @@ class PatientItem:
 
         query = {**query, **query_overrides}
 
-        results = Query.execute_dsl(query, all_results, auth_args)
+        results = Query.execute_fhir_dsl(query, all_results, auth_args)
 
         return pd.DataFrame(map(lambda r: r["_source"], results))

--- a/phc/easy/projects.py
+++ b/phc/easy/projects.py
@@ -1,8 +1,10 @@
-import pandas as pd
 from functools import reduce
+
+import pandas as pd
+
+import phc.services as services
 from funcy import memoize
 from phc.easy.auth import Auth
-import phc.services as services
 
 SEARCH_COLUMNS = ["name", "description", "id"]
 

--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, List, Union
 
 import pandas as pd
 
+from phc.services import Fhir
 from phc.easy.auth import Auth
 from phc.easy.query.fhir_dsl import (
     MAX_RESULT_SIZE,

--- a/phc/easy/query/fhir_dsl.py
+++ b/phc/easy/query/fhir_dsl.py
@@ -1,0 +1,89 @@
+from typing import Any, Callable, List, Union
+
+from phc.easy.auth import Auth
+from phc.services import Fhir
+
+try:
+    from tqdm.autonotebook import tqdm
+except ImportError:
+    _has_tqdm = False
+    tqdm = None
+else:
+    _has_tqdm = True
+
+MAX_RESULT_SIZE = 10000
+
+
+def with_progress(
+    init_progress: Callable[[], tqdm], func: Callable[[Union[None, tqdm]], None]
+):
+    if _has_tqdm:
+        progress = init_progress()
+        result = func(progress)
+        progress.close()
+        return result
+
+    return func(None)
+
+
+def query_allows_scrolling(query):
+    limit = iter(query.get("limit", []))
+
+    lower = next(limit, {}).get("value")
+    upper = next(limit, {}).get("value")
+
+    return isinstance(lower, int) and isinstance(upper, int)
+
+
+def recursive_execute_fhir_dsl(
+    query: dict,
+    scroll: bool = False,
+    progress: Union[None, tqdm] = None,
+    auth_args: Auth = Auth.shared(),
+    callback: Union[Callable[[Any, bool], None], None] = None,
+    _scroll_id: str = "true",
+    _prev_hits: List = [],
+):
+    auth = Auth(auth_args)
+    fhir = Fhir(auth.session())
+
+    response = fhir.execute_es(
+        auth.project_id,
+        query,
+        _scroll_id if query_allows_scrolling(query) and scroll else "",
+    )
+
+    is_first_iteration = _scroll_id == "true"
+    current_results = response.data.get("hits").get("hits")
+    _scroll_id = response.data.get("_scroll_id", "")
+    actual_count = response.data["hits"]["total"]["value"]
+    current_result_count = len(current_results)
+
+    if is_first_iteration and progress:
+        progress.reset(actual_count)
+
+    if progress:
+        progress.update(current_result_count)
+
+    is_last_batch = current_result_count == 0 or scroll is False
+    results = [] if callback else [*_prev_hits, *current_results]
+
+    if callback and not is_last_batch:
+        callback(current_results, False)
+    elif callback and is_last_batch:
+        return callback(current_results, True)
+    elif is_last_batch:
+        suffix = "+" if actual_count == MAX_RESULT_SIZE else ""
+        print(f"Retrieved {len(results)}/{actual_count}{suffix} results")
+
+        return results
+
+    return recursive_execute_fhir_dsl(
+        query,
+        scroll=True,
+        progress=progress,
+        auth_args=auth,
+        callback=callback,
+        _scroll_id=_scroll_id,
+        _prev_hits=results,
+    )

--- a/phc/easy/util.py
+++ b/phc/easy/util.py
@@ -4,7 +4,11 @@ from typing import Union
 
 def join_underscore(values):
     return "_".join(
-        [str(value) for value in values if type(value) == int or len(value) > 0]
+        [
+            str(value)
+            for value in values
+            if isinstance(value, int) or len(value) > 0
+        ]
     )
 
 
@@ -13,7 +17,7 @@ def without_keys(dictionary, keys):
 
 
 def prefix_dict_keys(dictionary, prefix: Union[str, int]):
-    if type(prefix) == str and len(prefix) == 0:
+    if isinstance(prefix, str) and len(prefix) == 0:
         return dictionary
 
     return {f"{prefix}_{key}": value for key, value in dictionary.items()}

--- a/phc/util/api_cache.py
+++ b/phc/util/api_cache.py
@@ -1,0 +1,20 @@
+import hashlib
+import json
+
+
+class APICache:
+    @staticmethod
+    def filename_for_fhir_dsl(query: dict):
+        "Descriptive filename with hash of query for easy retrieval"
+        components = [
+            "fhir",
+            "dsl",
+            *[d.get("table", "") for d in query.get("from", [])],
+            f"{len(query.get('columns', []))}col"
+            if isinstance(query.get("columns"), list)
+            else "",
+            "where" if query.get("where") else "",
+            hashlib.sha256(json.dumps(query).encode("utf-8")).hexdigest()[0:8],
+        ]
+
+        return "_".join([c for c in components if len(c) > 0]) + ".csv"

--- a/phc/util/api_cache.py
+++ b/phc/util/api_cache.py
@@ -1,5 +1,13 @@
 import hashlib
 import json
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+
+from phc.util.csv_writer import CSVWriter
+
+DIR = "~/_phc/api-cache"
 
 
 class APICache:
@@ -18,3 +26,44 @@ class APICache:
         ]
 
         return "_".join([c for c in components if len(c) > 0]) + ".csv"
+
+    @staticmethod
+    def does_cache_for_fhir_dsl_exist(query: dict) -> bool:
+        return (
+            Path(DIR)
+            .expanduser()
+            .joinpath(APICache.filename_for_fhir_dsl(query))
+            .exists()
+        )
+
+    @staticmethod
+    def load_cache_for_fhir_dsl(query: dict) -> pd.DataFrame:
+        filename = str(
+            Path(DIR)
+            .expanduser()
+            .joinpath(APICache.filename_for_fhir_dsl(query))
+        )
+        print(f'Loading cache from "{filename}"')
+
+        return pd.read_csv(filename)
+
+    @staticmethod
+    def build_cache_fhir_dsl_callback(
+        query: dict, transform: Callable[[pd.DataFrame], pd.DataFrame]
+    ):
+        folder = Path(DIR).expanduser()
+        folder.mkdir(parents=True, exist_ok=True)
+
+        filename = str(folder.joinpath(APICache.filename_for_fhir_dsl(query)))
+
+        writer = CSVWriter(filename)
+
+        def handle_batch(batch, is_finished):
+            if is_finished:
+                print(f'Loading data frame from "{filename}"')
+                return pd.read_csv(filename)
+
+            df = pd.DataFrame(map(lambda r: r["_source"], batch))
+            writer.write(transform(df))
+
+        return handle_batch

--- a/phc/util/api_cache.py
+++ b/phc/util/api_cache.py
@@ -18,15 +18,25 @@ class APICache:
     @staticmethod
     def filename_for_fhir_dsl(query: dict):
         "Descriptive filename with hash of query for easy retrieval"
+        column_description = (
+            f"{len(query.get('columns', []))}col"
+            if isinstance(query.get("columns"), list)
+            else ""
+        )
+
+        where_description = "where" if query.get("where") else ""
+
+        unique_hash = hashlib.sha256(
+            json.dumps(query).encode("utf-8")
+        ).hexdigest()[0:8]
+
         components = [
             "fhir",
             "dsl",
             *[d.get("table", "") for d in query.get("from", [])],
-            f"{len(query.get('columns', []))}col"
-            if isinstance(query.get("columns"), list)
-            else "",
-            "where" if query.get("where") else "",
-            hashlib.sha256(json.dumps(query).encode("utf-8")).hexdigest()[0:8],
+            column_description,
+            where_description,
+            unique_hash,
         ]
 
         return "_".join([c for c in components if len(c) > 0]) + ".csv"

--- a/phc/util/csv_writer.py
+++ b/phc/util/csv_writer.py
@@ -1,0 +1,61 @@
+import os
+from io import StringIO
+import pandas as pd
+
+
+class CSVWriter:
+    """Class for progressively writing batches of pandas data frames to a CSV
+    file where additional columns may be added in subsequent writes
+    """
+
+    def __init__(self, filename: str):
+        self.filename = filename
+        self.bak_filename = filename + ".bak"
+        self.batch_filename = filename + ".batch.bak"
+
+    def write(self, frame: pd.DataFrame):
+        """Write a data frame to an existing CSV file without loading the entire
+        file into memory
+        """
+        if not os.path.exists(self.filename):
+            frame.to_csv(self.filename, index=False)
+            return
+
+        self._copy_to_backup_file_without_header()
+
+        original_columns = self._columns()
+        new_columns = [c for c in frame.columns if c not in original_columns]
+        columns_not_in_this_batch = [
+            c for c in original_columns if c not in frame.columns
+        ]
+
+        # Create frame with all columns (order doesn't matter here)
+        superset_frame = pd.concat(
+            [frame, pd.DataFrame(None, columns=columns_not_in_this_batch)]
+        )
+
+        # Create ordered list to select order of values when writing to the file
+        ordered_columns = [*original_columns, *new_columns]
+
+        superset_frame[ordered_columns].to_csv(self.batch_filename, index=False)
+
+        self._finalize()
+
+    def _columns(self):
+        with open(self.filename, "r") as f:
+            header = f.readline()
+
+        return pd.read_csv(StringIO(header)).columns.tolist()
+
+    def _copy_to_backup_file_without_header(self):
+        os.system(f"sed 1,1d {self.filename} > {self.bak_filename}")
+
+    def _finalize(self):
+        os.system(
+            f"""
+          head -n 1 {self.batch_filename} > {self.filename} && \
+            cat {self.bak_filename} >> {self.filename} && \
+            sed 1,1d {self.batch_filename} >> {self.filename} && \
+            rm {self.batch_filename} {self.bak_filename}
+        """
+        )

--- a/phc/util/csv_writer.py
+++ b/phc/util/csv_writer.py
@@ -18,7 +18,9 @@ class CSVWriter:
         file into memory
         """
         if not os.path.exists(self.filename):
-            frame.to_csv(self.filename, index=False)
+            frame.to_csv(
+                self.filename, date_format="%Y-%m-%dT%H:%M:%S%z", index=False
+            )
             return
 
         self._copy_to_backup_file_without_header()

--- a/tests/test_csv_writer.py
+++ b/tests/test_csv_writer.py
@@ -1,0 +1,56 @@
+import math
+import os
+
+import numpy as np
+import pandas as pd
+
+from phc.util.csv_writer import CSVWriter
+
+
+def setup():
+    if os.path.exists("/tmp/sample.csv"):
+        os.remove("/tmp/sample.csv")
+
+
+def test_writing_batches():
+    setup()
+    writer = CSVWriter("/tmp/sample.csv")
+
+    first_batch = pd.DataFrame(
+        [
+            {"first_name": "Laura", "last_name": "Lane"},
+            {"first_name": "Susie", "last_name": "Smith"},
+        ]
+    )
+
+    second_batch = pd.DataFrame(
+        [
+            {"first_name": "Jenny", "last_name": "Jones"},
+            {"last_name": "Motte", "date_of_birth": "03/07/1986"},
+        ]
+    )
+
+    writer.write(first_batch)
+    writer.write(second_batch)
+
+    frame = pd.read_csv("/tmp/sample.csv")
+
+    assert frame.columns.tolist() == [
+        "first_name",
+        "last_name",
+        "date_of_birth",
+    ]
+
+    # Cannot compare NaN - must use math.isnan()
+    is_nan = np.vectorize(lambda x: isinstance(x, float) and math.isnan(x))
+
+    assert np.logical_or(
+        frame.values
+        == [
+            ["Laura", "Lane", math.nan],
+            ["Susie", "Smith", math.nan],
+            ["Jenny", "Jones", math.nan],
+            [math.nan, "Motte", "03/07/1986"],
+        ],
+        is_nan(frame.values),
+    ).all()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,54 @@
+from phc.util.api_cache import APICache
+
+
+def test_filename_for_fhir_dsl_with_simple_statement():
+    filename = APICache.filename_for_fhir_dsl(
+        {
+            "type": "select",
+            "columns": "*",
+            "from": [{"table": "patient"}, {"table": "observation"}],
+        }
+    )
+
+    assert filename == "fhir_dsl_patient_observation_c57bdb78.csv"
+
+
+def test_filename_for_fhir_dsl_with_complex_statement():
+    filename = APICache.filename_for_fhir_dsl(
+        {
+            "type": "select",
+            "columns": [
+                {
+                    "type": "elasticsearch",
+                    "aggregations": {
+                        "results": {
+                            "cardinality": {"field": "person.ref.keyword"}
+                        }
+                    },
+                }
+            ],
+            "from": [{"table": "goal"}],
+            "where": {
+                "type": "elasticsearch",
+                "query": {
+                    "bool": {
+                        "should": [
+                            {
+                                "term": {
+                                    "target.measure.coding.system.keyword": "http://my-system/fhir/measure1"
+                                }
+                            },
+                            {
+                                "term": {
+                                    "target.measure.coding.code.keyword": "12345-6"
+                                }
+                            },
+                        ],
+                        "minimum_should_match": 2,
+                    }
+                },
+            },
+        }
+    )
+
+    assert filename == "fhir_dsl_goal_1col_where_58a8bb32.csv"


### PR DESCRIPTION
When we attempt to pull millions of records, we don't want to have the RAM go through the roof. Likewise, we don't want to keep hitting the FSS unless really required. When the same FSS query is run and we are retrieving all of the results, we'd like to ideally cache the results automatically. We don't care about this for Projects, but we do for Patient, Observation, Procedure, and other future entities. The `transform` attribute you'll see throughout is for performing the FHIR code column expansion before each batch is written to a file.

The basis for this caching is the `CSVWriter` which can handle writing multiple pandas data frames to the same CSV file. Although python has some support for changing the read/write cursor in a file, it doesn't have enough support to do the merging of multiple CSV files without reading the entire thing into memory. Therefore, I've had to opt for several fun bash one-liners to accomplish what's necessary within our target performance of O(1).

The goal of this easy module is to really make stuff "just work" but allow customization when a user needs more powerful customization based on their data. In this mindset, the CSV cache files are named something semi-description but still unique based on the hash of the FSS query. I really like the direction it's heading. All of this has been validated in the notebook environment or with unit tests. We'll be using this in our next projects. 😉

Here's an example of a run:
```python
phc.Observation.get_data_frame(patient_id=SAMPLE_PATIENT_ID, all_results=True)
# 100% 2252/2252 [00:01<00:00, 2111.26it/s]
# Loading data frame from "/home/*****/_phc/api-cache/fhir_dsl_observation_where_1071793d.csv"
```
As a later feature, we could customize the directory that these cached files are stored. Of course, you can skip the caching feature if desired or execute a raw query.