### PR TITLE
Auto-add patient filters

### DIFF
--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List
 
 import pandas as pd
 
@@ -44,6 +44,7 @@ class PatientItem:
         all_results: bool = False,
         raw: bool = False,
         patient_id: Union[None, str] = None,
+        patient_ids: List[str] = [],
         query_overrides: dict = {},
         auth_args=Auth.shared(),
         ignore_cache: bool = False,
@@ -86,9 +87,11 @@ class PatientItem:
         >>>
         >>> phc.Goal.get_data_frame(patient_id='<patient-id>')
         """
-        query = PatientItem.build_query(
-            cls.table_name(), patient_id, cls.patient_key()
-        )
+        query = {
+            "type": "select",
+            "columns": "*",
+            "from": [{"table": cls.table_name()}],
+        }
 
         def transform(df: pd.DataFrame):
             return cls.transform_results(df, **expand_args)
@@ -101,45 +104,7 @@ class PatientItem:
             query_overrides,
             auth_args,
             ignore_cache,
+            patient_id=patient_id,
+            patient_ids=patient_ids,
+            patient_key=cls.patient_key(),
         )
-
-    @staticmethod
-    def build_query(
-        table_name: str,
-        patient_id: Union[None, str] = None,
-        patient_key: str = "subject.reference",
-    ) -> dict:
-        """Build query for a given table that relates to a patient
-
-        Attributes
-        ----------
-        table_name : str
-            The name of the elasticsearch FHIR table
-
-        patient_id : None or str = None
-            Find table records for a given patient_id
-        """
-
-        query = {
-            "type": "select",
-            "columns": "*",
-            "from": [{"table": table_name}],
-        }
-
-        if patient_id:
-            return {
-                **query,
-                "where": {
-                    "type": "elasticsearch",
-                    "query": {
-                        "terms": {
-                            f"{patient_key}.keyword": [
-                                patient_id,
-                                f"Patient/{patient_id}",
-                            ]
-                        }
-                    },
-                },
-            }
-
-        return query

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -49,6 +49,7 @@ class PatientItem:
         auth_args=Auth.shared(),
         ignore_cache: bool = False,
         expand_args: dict = {},
+        log: bool = False,
     ):
         """Retrieve records
 
@@ -76,6 +77,9 @@ class PatientItem:
 
         expand_args : Any
             Additional arguments passed to phc.Frame.expand
+
+        log : bool = False
+            Whether to log some diagnostic statements for debugging
 
         Examples
         --------
@@ -107,4 +111,5 @@ class PatientItem:
             patient_id=patient_id,
             patient_ids=patient_ids,
             patient_key=cls.patient_key(),
+            log=log,
         )

--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -65,6 +65,7 @@ class Query:
         all_results: bool = False,
         auth_args: Auth = Auth.shared(),
         callback: Union[Callable[[Any, bool], None], None] = None,
+        log: bool = False,
         **query_kwargs,
     ):
         """Execute a FHIR query with the DSL
@@ -96,6 +97,9 @@ class Query:
                     if is_finished:
                         return "batch finished
 
+        log : bool = False
+            Whether to log the elasticsearch query sent to the server
+
         query_kwargs : dict
             Arguments to pass to build_query such as patient_id, patient_ids,
             and patient_key. (See phc.easy.query.fhir_dsl_query.build_query)
@@ -115,6 +119,9 @@ class Query:
 
         """
         query = build_query(query, **query_kwargs)
+
+        if log:
+            print(query)
 
         if all_results:
             return with_progress(
@@ -152,9 +159,13 @@ class Query:
         query_overrides: dict,
         auth_args: Auth,
         ignore_cache: bool,
+        log: bool = False,
         **query_kwargs,
     ):
         query = build_query({**query, **query_overrides}, **query_kwargs)
+
+        if log:
+            print(query)
 
         use_cache = (not ignore_cache) and (not raw) and all_results
 

--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -6,6 +6,7 @@ from phc.services import Fhir
 from phc.base_client import BaseClient
 from phc.easy.auth import Auth
 from phc.easy.query.ga4gh import recursive_execute_ga4gh
+from phc.easy.query.fhir_dsl_query import build_query
 from phc.easy.query.fhir_dsl import (
     MAX_RESULT_SIZE,
     recursive_execute_fhir_dsl,
@@ -64,6 +65,7 @@ class Query:
         all_results: bool = False,
         auth_args: Auth = Auth.shared(),
         callback: Union[Callable[[Any, bool], None], None] = None,
+        **query_kwargs,
     ):
         """Execute a FHIR query with the DSL
 
@@ -94,6 +96,10 @@ class Query:
                     if is_finished:
                         return "batch finished
 
+        query_kwargs : dict
+            Arguments to pass to build_query such as patient_id, patient_ids,
+            and patient_key. (See phc.easy.query.fhir_dsl_query.build_query)
+
         Examples
         --------
         >>> import phc.easy as phc
@@ -108,6 +114,8 @@ class Query:
         }, all_results=True)
 
         """
+        query = build_query(query, **query_kwargs)
+
         if all_results:
             return with_progress(
                 lambda: tqdm(total=MAX_RESULT_SIZE),
@@ -144,8 +152,9 @@ class Query:
         query_overrides: dict,
         auth_args: Auth,
         ignore_cache: bool,
+        **query_kwargs,
     ):
-        query = {**query, **query_overrides}
+        query = build_query({**query, **query_overrides}, **query_kwargs)
 
         use_cache = (not ignore_cache) and (not raw) and all_results
 

--- a/phc/easy/query/fhir_dsl_query.py
+++ b/phc/easy/query/fhir_dsl_query.py
@@ -1,0 +1,62 @@
+from typing import List, Union
+from lenses import lens
+
+FHIR_WHERE = lens.Get("where", {})
+FHIR_SIMPLE_QUERY = FHIR_WHERE.Get("query", {})
+FHIR_BOOL_QUERY = FHIR_SIMPLE_QUERY.Get("bool", {})
+
+
+def add_should_clause(query: dict, should_clause: dict):
+    "Append a term/terms clause to an existing FSS query"
+    if FHIR_WHERE.get()(query) == {}:
+        return FHIR_SIMPLE_QUERY.set(should_clause)(query)
+
+    query_keys = FHIR_SIMPLE_QUERY.get()(query).keys()
+    if len(query_keys) == 1 and ("term" in query_keys or "terms" in query_keys):
+
+        def combined_with_term(query_clause):
+            return {
+                "bool": {
+                    "should": [query_clause, should_clause],
+                    "minimum_should_match": 2,
+                }
+            }
+
+        return FHIR_SIMPLE_QUERY.modify(combined_with_term)(query)
+
+    bool_keys = FHIR_BOOL_QUERY.get()(query).keys()
+    if "should" in bool_keys:
+
+        def combined_with_bool(query_with_bool_clause):
+            return {
+                "bool": {
+                    "should": [query_with_bool_clause, should_clause],
+                    "minimum_should_match": 2,
+                }
+            }
+
+        return FHIR_SIMPLE_QUERY.modify(combined_with_bool)(query)
+
+    raise ValueError("Could not add clause to query", should_clause, query)
+
+
+def build_query(
+    query: dict,
+    patient_id: Union[str, None] = None,
+    patient_ids: List[str] = [],
+    patient_key: str = "subject.reference",
+):
+    "Build query with patient_ids"
+    patient_ids = [*patient_ids, *([patient_id] if patient_id else [])]
+
+    return add_should_clause(
+        query,
+        {
+            "terms": {
+                f"{patient_key}.keyword": [
+                    *[f"Patient/{patient_id}" for patient_id in patient_ids],
+                    *patient_ids,
+                ]
+            }
+        },
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyjwt
 pandas
 funcy
 lenses
+toolz

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nest_asyncio
 pyjwt
 pandas
 funcy
+lenses

--- a/tests/test_fhir_dsl_query.py
+++ b/tests/test_fhir_dsl_query.py
@@ -1,0 +1,95 @@
+from phc.easy.query.fhir_dsl_query import build_query
+
+
+def test_add_patient_ids_with_no_where_clause():
+    assert build_query({}, patient_ids=["a"]) == {
+        "where": {
+            "query": {
+                "terms": {"subject.reference.keyword": ["Patient/a", "a"]}
+            }
+        }
+    }
+
+
+def test_add_patient_id_with_query_term():
+    result = build_query(
+        {
+            "where": {
+                "type": "elasticsearch",
+                "query": {"term": {"test.field.keyword": "blah"}},
+            }
+        },
+        patient_ids=["a", "b"],
+    )
+
+    assert result == {
+        "where": {
+            "type": "elasticsearch",
+            "query": {
+                "bool": {
+                    "should": [
+                        {"term": {"test.field.keyword": "blah"}},
+                        {
+                            "terms": {
+                                "subject.reference.keyword": [
+                                    "Patient/a",
+                                    "Patient/b",
+                                    "a",
+                                    "b",
+                                ]
+                            }
+                        },
+                    ],
+                    "minimum_should_match": 2,
+                }
+            },
+        }
+    }
+
+
+def test_add_patient_id_with_bool_should_query():
+    result = build_query(
+        {
+            "where": {
+                "type": "elasticsearch",
+                "query": {
+                    "bool": {"should": [{"term": {"gender.keyword": "male"}}]}
+                },
+            }
+        },
+        patient_ids=["a"],
+        patient_key="id",
+    )
+
+    assert result == {
+        "where": {
+            "type": "elasticsearch",
+            "query": {
+                "bool": {
+                    "should": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {"term": {"gender.keyword": "male"}}
+                                ],
+                            }
+                        },
+                        {"terms": {"id.keyword": ["Patient/a", "a"]}},
+                    ],
+                    "minimum_should_match": 2,
+                }
+            },
+        }
+    }
+
+
+def test_add_single_patient_id_to_query():
+    result = build_query({}, patient_id="a")
+
+    assert result == {
+        "where": {
+            "query": {
+                "terms": {"subject.reference.keyword": ["Patient/a", "a"]}
+            }
+        }
+    }

--- a/tests/test_fhir_dsl_query.py
+++ b/tests/test_fhir_dsl_query.py
@@ -1,12 +1,30 @@
+from nose.tools import raises
 from phc.easy.query.fhir_dsl_query import build_query
+
+
+def test_no_modification():
+    example = {
+        "where": {
+            "type": "elasticsearch",
+            "query": {"term": {"gender.keyword": "male"}},
+        }
+    }
+
+    assert build_query(example) == example
+
+
+@raises(ValueError)
+def test_throws_with_non_elasticsearch_where():
+    build_query({"where": {"query": "blah-blah-blah"}}, patient_id="a")
 
 
 def test_add_patient_ids_with_no_where_clause():
     assert build_query({}, patient_ids=["a"]) == {
         "where": {
+            "type": "elasticsearch",
             "query": {
                 "terms": {"subject.reference.keyword": ["Patient/a", "a"]}
-            }
+            },
         }
     }
 
@@ -88,8 +106,9 @@ def test_add_single_patient_id_to_query():
 
     assert result == {
         "where": {
+            "type": "elasticsearch",
             "query": {
                 "terms": {"subject.reference.keyword": ["Patient/a", "a"]}
-            }
+            },
         }
     }


### PR DESCRIPTION
Simple example:

```python
phc.Observation.get_data_frame(
    patient_ids=["id1", "id2"],
    query_overrides={
        "where": {
            "type": "elasticsearch",
            "query": {
                "term": {
                    "code.coding.code.keyword": "heartRate"
                }
            }
        }
    },
    log=True
)
```

produces the following query

```json
{
  "type": "select",
  "columns": "*",
  "from": [
    {
      "table": "observation"
    }
  ],
  "where": {
    "type": "elasticsearch",
    "query": {
      "bool": {
        "should": [
          {
            "term": {
              "code.coding.code.keyword": "heartRate"
            }
          },
          {
            "terms": {
              "subject.reference.keyword": [
                "Patient/id1",
                "Patient/id2",
                "id1",
                "id2"
              ]
            }
          }
        ],
        "minimum_should_match": 2
      }
    }
  }
}
```