### PR TITLE
Add first-class support for easy aggregations

### DIFF
--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -113,3 +113,51 @@ class PatientItem:
             patient_key=cls.patient_key(),
             log=log,
         )
+
+    @classmethod
+    def get_count_by_field(cls, field: str, **kwargs):
+        """Count records by a given field
+
+        See argments for :func:`~phc.easy.query.Query.get_count_by_field`
+
+        Attributes
+        ----------
+        field : str
+            The field name to count the values of (e.g. "gender")
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({'account': '<your-account-name>'})
+        >>> phc.Project.set_current('My Project Name')
+        >>>
+        >>> phc.Observation.get_count_by_field('category.coding.code')
+        """
+        return Query.get_count_by_field(
+            table_name=cls.table_name(), field=field, **kwargs
+        )
+
+    @classmethod
+    def get_count_by_patient(cls, **kwargs):
+        """Count records by a given field
+
+        See argments for :func:`~phc.easy.query.Query.get_count_by_field`
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({'account': '<your-account-name>'})
+        >>> phc.Project.set_current('My Project Name')
+        >>>
+        >>> phc.Observation.get_count_by_patient('gender')
+        """
+        patient_key = cls.patient_key()
+
+        df = Query.get_count_by_field(
+            table_name=cls.table_name(), field=cls.patient_key(), **kwargs
+        )
+
+        # Make keys consistent (some are prefixed while others are not)
+        df[patient_key] = df[patient_key].str.replace("Patient/", "")
+
+        return df.groupby(patient_key).sum()

--- a/phc/easy/query/fhir_aggregation.py
+++ b/phc/easy/query/fhir_aggregation.py
@@ -1,0 +1,19 @@
+from typing import NamedTuple
+
+
+class FhirAggregation(NamedTuple):
+    data: dict
+
+    @staticmethod
+    def from_response(response: dict):
+        return FhirAggregation(response["aggregations"])
+
+    @staticmethod
+    def is_aggregation_query(query: dict):
+        if not isinstance(query.get("columns"), list):
+            return False
+
+        return (
+            next(filter(lambda c: "aggregations" in c, query["columns"]), None)
+            is not None
+        )

--- a/phc/easy/query/fhir_dsl.py
+++ b/phc/easy/query/fhir_dsl.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, List, Union
 
+import pandas as pd
+
 from phc.easy.auth import Auth
 from phc.services import Fhir
 

--- a/phc/util/api_cache.py
+++ b/phc/util/api_cache.py
@@ -103,8 +103,8 @@ class APICache:
         filename = str(folder.joinpath(APICache.filename_for_fhir_dsl(query)))
 
         print(f'Writing aggregation to "{filename}"')
-        with open(filename, "w") as f:
-            json.dump(agg, f, indent=2)
+        with open(filename, "w") as file:
+            json.dump(agg.data, file, indent=2)
 
     @staticmethod
     def read_csv(filename: str) -> pd.DataFrame:

--- a/phc/util/api_cache.py
+++ b/phc/util/api_cache.py
@@ -6,6 +6,7 @@ from typing import Callable
 import numpy as np
 import pandas as pd
 
+from phc.easy.query.fhir_aggregation import FhirAggregation
 from phc.util.csv_writer import CSVWriter
 
 DIR = "~/Downloads/phc/api-cache"
@@ -18,9 +19,13 @@ class APICache:
     @staticmethod
     def filename_for_fhir_dsl(query: dict):
         "Descriptive filename with hash of query for easy retrieval"
+        is_aggregation = FhirAggregation.is_aggregation_query(query)
+
+        agg_description = "agg" if is_aggregation else ""
+
         column_description = (
             f"{len(query.get('columns', []))}col"
-            if isinstance(query.get("columns"), list)
+            if not is_aggregation and isinstance(query.get("columns"), list)
             else ""
         )
 
@@ -34,12 +39,15 @@ class APICache:
             "fhir",
             "dsl",
             *[d.get("table", "") for d in query.get("from", [])],
+            agg_description,
             column_description,
             where_description,
             unique_hash,
         ]
 
-        return "_".join([c for c in components if len(c) > 0]) + ".csv"
+        extension = "json" if is_aggregation else "csv"
+
+        return "_".join([c for c in components if len(c) > 0]) + "." + extension
 
     @staticmethod
     def does_cache_for_fhir_dsl_exist(query: dict) -> bool:
@@ -57,7 +65,11 @@ class APICache:
             .expanduser()
             .joinpath(APICache.filename_for_fhir_dsl(query))
         )
-        print(f'Loading cache from "{filename}"')
+        print(f'[CACHE] Loading from "{filename}"')
+
+        if FhirAggregation.is_aggregation_query(query):
+            with open(filename, "r") as f:
+                return FhirAggregation(json.load(f))
 
         return APICache.read_csv(filename)
 
@@ -65,6 +77,7 @@ class APICache:
     def build_cache_fhir_dsl_callback(
         query: dict, transform: Callable[[pd.DataFrame], pd.DataFrame]
     ):
+        "Build a CSV callback (not used for aggregations)"
         folder = Path(DIR).expanduser()
         folder.mkdir(parents=True, exist_ok=True)
 
@@ -81,6 +94,17 @@ class APICache:
             writer.write(transform(df))
 
         return handle_batch
+
+    @staticmethod
+    def write_agg(query: dict, agg: FhirAggregation):
+        folder = Path(DIR).expanduser()
+        folder.mkdir(parents=True, exist_ok=True)
+
+        filename = str(folder.joinpath(APICache.filename_for_fhir_dsl(query)))
+
+        print(f'Writing aggregation to "{filename}"')
+        with open(filename, "w") as f:
+            json.dump(agg, f, indent=2)
 
     @staticmethod
     def read_csv(filename: str) -> pd.DataFrame:

--- a/tests/test_fhir_aggregation.py
+++ b/tests/test_fhir_aggregation.py
@@ -1,0 +1,40 @@
+from phc.easy.query.fhir_aggregation import FhirAggregation
+
+
+def test_is_aggregation_query():
+    query = {
+        "type": "select",
+        "columns": [
+            # Expression columns are ignored when aggregations are present
+            {"expr": {"type": "column_ref", "column": "id.keyword"}},
+            {
+                "type": "elasticsearch",
+                "aggregations": {
+                    "results": {"terms": {"field": "subject.reference.keyword"}}
+                },
+            },
+        ],
+        "from": [{"table": "observation"}],
+    }
+
+    assert FhirAggregation.is_aggregation_query(query)
+
+
+def test_is_not_aggregation_query_with_specific_column_selected():
+    query = {
+        "type": "select",
+        "columns": [{"expr": {"type": "column_ref", "column": "id.keyword"}}],
+        "from": [{"table": "observation"}],
+    }
+
+    assert not FhirAggregation.is_aggregation_query(query)
+
+
+def test_is_not_aggregation_query_with_all_columns():
+    query = {
+        "type": "select",
+        "columns": "*",
+        "from": [{"table": "observation"}],
+    }
+
+    assert not FhirAggregation.is_aggregation_query(query)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -18,6 +18,40 @@ def test_filename_for_fhir_dsl_with_complex_statement():
         {
             "type": "select",
             "columns": [
+                {"expr": {"type": "column_ref", "column": "id.keyword"}}
+            ],
+            "from": [{"table": "goal"}],
+            "where": {
+                "type": "elasticsearch",
+                "query": {
+                    "bool": {
+                        "should": [
+                            {
+                                "term": {
+                                    "target.measure.coding.system.keyword": "http://my-system/fhir/measure1"
+                                }
+                            },
+                            {
+                                "term": {
+                                    "target.measure.coding.code.keyword": "12345-6"
+                                }
+                            },
+                        ],
+                        "minimum_should_match": 2,
+                    }
+                },
+            },
+        }
+    )
+
+    assert filename == "fhir_dsl_goal_1col_where_08c25b4c.csv"
+
+
+def test_filename_for_fhir_dsl_with_aggregation():
+    filename = APICache.filename_for_fhir_dsl(
+        {
+            "type": "select",
+            "columns": [
                 {
                     "type": "elasticsearch",
                     "aggregations": {
@@ -51,4 +85,4 @@ def test_filename_for_fhir_dsl_with_complex_statement():
         }
     )
 
-    assert filename == "fhir_dsl_goal_1col_where_58a8bb32.csv"
+    assert filename == "fhir_dsl_goal_agg_where_58a8bb32.json"


### PR DESCRIPTION
This support uses the ES aggregations but makes them easily accessible and performs the necessary paging. It integrates with the `PatientItem` entities (Observation, Procedure, etc) but also allows all of the query and auth customization available from all of the easy module calls.

Example 1 (using the open BRCA data set): **Get the display codes counts for observations on two patients**
```python
phc.Observation.get_count_by_field(
    field="code.coding.display",
    # Note that patient_ids gets passed through to a inside function call
    # (i.e. existing filtering options are supported)
    patient_ids=[
        "eafa45a4-2fd1-4fa3-860c-9d52ed382b7d",
        "6412854a-f874-469e-9d1f-8bd3ae5bd41d"
    ]
)
```
Result 1:
```
            code.coding.display  doc_count
0             Date of Diagnosis          2
1   Date of Disease Progression          1
2          Date of Last Contact          2
3      Estrogen Receptor Status          2
4      HER2/neu receptor status          2
5  Progesterone Receptor Status          2
```

Example 2 (using the open BRCA data set): **Get the specimen count by patient**
```python
phc.Specimen.get_count_by_patient()
```

Result 2:
```
                                      doc_count
subject.reference                              
001cef41-ff86-4d3f-a140-a647ac4b10a1          5
0045349c-69d9-4306-a403-c9c1fa836644          2
00807dae-9f4a-4fd1-aac2-82eb11bf2afb          3
00a2d166-78c9-4687-a195-3d6315c27574          5
00b11ca8-8540-4a3d-b602-ec754b00230b          5
011b9b2d-ebe5-42bf-9662-d922faccc7a1          3
01263518-5f7c-49dc-8d7e-84b0c03a6a63          4
0130d616-885e-4a6c-9d03-2f17dd692a05          3
01674b2c-5cf2-478f-84a1-f69c39f47bd4          4
016caf42-4e19-4444-ab5d-6cf1e76c4afa          5
...
```

Example 3 (using the underlying aggregation call): **Find count of observations that have a valueDateTime that exists**
```python
phc.Query.execute_fhir_dsl({
    "type": "select",
    "from": [{"table": "observation"}],
    "columns": [{
        "type": "elasticsearch",
        "aggregations": {
            "result": {
                "value_count": {
                    "field": "valueDateTime"
                }
            }
        }
    }]
})

# or this could be written at the entity level (which will perform caching)

phc.Observation.get_data_frame(query_overrides={
    "columns": [{
        "type": "elasticsearch",
        "aggregations": {
            "result": {
                "value_count": {
                    "field": "valueDateTime"
                }
            }
        }
    }]
})
# => Writing aggregation to "~/Downloads/phc/api-cache/fhir_dsl_observation_agg_c485200d.json"
```

Result 3:
```
FhirAggregation(data={'result': {'value': 2332}})
```