### PR TITLE
Add composite aggregations and codes

### DIFF
--- a/phc/easy/condition.py
+++ b/phc/easy/condition.py
@@ -10,6 +10,15 @@ class Condition(PatientItem):
         return "condition"
 
     @staticmethod
+    def code_keys():
+        return [
+            "meta.tag",
+            "code.coding",
+            "bodySite.coding",
+            "stage.summary.coding",
+        ]
+
+    @staticmethod
     def transform_results(df: pd.DataFrame, **expand_args):
         return Frame.expand(
             df,

--- a/phc/easy/goal.py
+++ b/phc/easy/goal.py
@@ -10,6 +10,10 @@ class Goal(PatientItem):
         return "goal"
 
     @staticmethod
+    def code_keys():
+        return ["meta.tag", "target.detailQuantity", "target.measure.coding"]
+
+    @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {
             **expand_args,

--- a/phc/easy/observation.py
+++ b/phc/easy/observation.py
@@ -10,6 +10,16 @@ class Observation(PatientItem):
         return "observation"
 
     @staticmethod
+    def code_keys():
+        return [
+            "meta.tag",
+            "code.coding",
+            "component.code.coding",
+            "valueCodeableConcept.coding",
+            "category.coding",
+        ]
+
+    @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {
             **expand_args,

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from phc.easy.auth import Auth
 from phc.easy.query import Query
+from phc.easy.util import without_keys
 
 
 class PatientItem:
@@ -19,6 +20,11 @@ class PatientItem:
     @staticmethod
     def patient_key() -> str:
         return "subject.reference"
+
+    @staticmethod
+    def code_keys() -> List[str]:
+        "Returns the code keys (e.g. when searching for codes)"
+        return []
 
     @classmethod
     def get_count(cls, query_overrides: dict = {}, auth_args=Auth.shared()):
@@ -112,6 +118,28 @@ class PatientItem:
             patient_ids=patient_ids,
             patient_key=cls.patient_key(),
             log=log,
+        )
+
+    @classmethod
+    def get_codes(cls, **kwargs):
+        """Find all codes
+
+        See possible argments for :func:`~phc.easy.query.Query.get_codes`
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({'account': '<your-account-name>'})
+        >>> phc.Project.set_current('My Project Name')
+        >>>
+        >>> phc.Observation.get_codes(patient_id="<id>", max_pages=3)
+        """
+        code_fields = [*cls.code_keys(), *kwargs.get("code_fields", [])]
+
+        return Query.get_codes(
+            table_name=cls.table_name(),
+            code_fields=code_fields,
+            **without_keys(kwargs, ["code_fields"]),
         )
 
     @classmethod

--- a/phc/easy/procedure.py
+++ b/phc/easy/procedure.py
@@ -14,6 +14,10 @@ class Procedure(PatientItem):
         return "procedure"
 
     @staticmethod
+    def code_keys():
+        return ["meta.tag", "code.coding", "category.coding"]
+
+    @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {
             **expand_args,

--- a/phc/easy/procedure.py
+++ b/phc/easy/procedure.py
@@ -8,18 +8,10 @@ from phc.easy.patient_item import PatientItem
 from phc.easy.query import Query
 
 
-class Procedure:
+class Procedure(PatientItem):
     @staticmethod
-    def get_count(query_overrides: dict = {}, auth_args=Auth.shared()):
-        return Query.find_count_of_dsl_query(
-            {
-                "type": "select",
-                "columns": "*",
-                "from": [{"table": "procedure"}],
-                **query_overrides,
-            },
-            auth_args=auth_args,
-        )
+    def table_name():
+        return "procedure"
 
     @staticmethod
     def transform_results(data_frame: pd.DataFrame, **expand_args):
@@ -38,62 +30,3 @@ class Procedure:
         }
 
         return Frame.expand(data_frame, **args)
-
-    @staticmethod
-    def get_data_frame(
-        all_results: bool = False,
-        raw: bool = False,
-        patient_id: Union[None, str] = None,
-        query_overrides: dict = {},
-        auth_args=Auth.shared(),
-        ignore_cache: bool = False,
-        expand_args: dict = {},
-    ):
-        """Retrieve procedures
-
-        Attributes
-        ----------
-        all_results : bool = False
-            Retrieve sample of results (10) or entire set of procedures
-
-        raw : bool = False
-            If raw, then values will not be expanded (useful for manual
-            inspection if something goes wrong)
-
-        patient_id : None or str = None
-            Find procedures for a given patient_id
-
-        query_overrides : dict = {}
-            Override any part of the elasticsearch FHIR query
-
-        auth_args : Any
-            The authenication to use for the account and project (defaults to shared)
-
-        ignore_cache : bool = False
-            Bypass the caching system that auto-saves results to a CSV file.
-            Caching only occurs when all results are being retrieved.
-
-        expand_args : Any
-            Additional arguments passed to phc.Frame.expand
-
-        Examples
-        --------
-        >>> import phc.easy as phc
-        >>> phc.Auth.set({'account': '<your-account-name>'})
-        >>> phc.Project.set_current('My Project Name')
-        >>> phc.Procedure.get_data_frame(patient_id='<patient-id>')
-        """
-        query = PatientItem.build_query("procedure", patient_id)
-
-        def transform(df: pd.DataFrame):
-            return Procedure.transform_results(df, **expand_args)
-
-        return Query.execute_fhir_dsl_with_options(
-            query,
-            transform,
-            all_results,
-            raw,
-            query_overrides,
-            auth_args,
-            ignore_cache,
-        )

--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Union, NamedTuple
+from typing import Any, Callable, List, Union, NamedTuple, Tuple
 import pandas as pd
 
 from phc.services import Fhir
@@ -212,6 +212,122 @@ class Query:
         return transform(df)
 
     @staticmethod
+    def execute_composite_aggregations(
+        table_name: str,
+        key_sources_pairs: List[Tuple[str, List[dict]]],
+        batch_size: int = 100,
+        query_overrides: dict = {},
+        log: bool = False,
+        auth_args: Auth = Auth.shared(),
+        max_pages: Union[int, None] = None,
+        **query_kwargs,
+    ):
+        """Count records by a given field
+
+        Attributes
+        ----------
+        table_name : str
+            The FHIR Search Service table to retrieve from
+
+        key_sources_pairs : str
+            Pairs of keys and sources to pull composite results from
+
+            Example Input:
+                [
+                    ("meta.tag", [{"terms": {"field": "meta.tag.system.keyword"}}])
+                ]
+
+        batch_size : int
+            The size of each page from elasticsearch to use
+
+        query_overrides : dict
+            Parts of the FSS query to override
+            (Note that passing certain values can cause the method to error out)
+
+            Example aggregation query executed (can use log=True to inspect):
+                {
+                    "type": "select",
+                    "columns": [{
+                        "type": "elasticsearch",
+                        "aggregations": {
+                            "results": {
+                                "composite": {
+                                    "sources": [{
+                                        "meta.tag": {
+                                            "terms": {
+                                                "field": "meta.tag.system.keyword"
+                                            }
+                                        }
+                                    }],
+                                    "size": 100,
+                                }
+                            }
+                        },
+                    }],
+                    "from": [{"table": "observation"}],
+                }
+
+
+        auth_args : Auth, dict
+            Additional arguments for authentication
+
+        log : bool = False
+            Whether to log the elasticsearch query sent to the server
+
+        max_pages : int
+            The number of pages to retrieve (useful if working with tons of records)
+
+        query_kwargs : dict
+            Arguments to pass to build_query such as patient_id, patient_ids,
+            and patient_key. See :func:`~phc.easy.query.fhir_dsl_query.build_query`.
+
+        Examples
+        --------
+        >>> import phc.easy as phc
+        >>> phc.Auth.set({ 'account': '<your-account-name>' })
+        >>> phc.Project.set_current('My Project Name')
+        >>> phc.Query.execute_composite_aggregations(
+            table_name="observation",
+            key_sources_pairs=[
+                ("meta.tag", [
+                    {"system": {"terms": {"field": "meta.tag.system.keyword"}}},
+                    {"code": {"terms": {"field": "meta.tag.code.keyword"}}},
+                    {"display": {"terms": {"field": "meta.tag.display.keyword"}}},
+                ]),
+                ("code.coding", [
+                    {"display": {"terms": {"field": "code.coding.display.keyword"}}}
+                ]),
+            ]
+        )
+        """
+
+        return with_progress(
+            tqdm,
+            lambda progress: Query._recursive_execute_composite_aggregations(
+                table_name=table_name,
+                key_sources_pairs=key_sources_pairs,
+                batch_size=batch_size,
+                progress=progress,
+                log=log,
+                auth_args=auth_args,
+                query_overrides=query_overrides,
+                max_pages=max_pages,
+                **query_kwargs,
+            ),
+        )
+
+    # @staticmethod
+    # def find_codes(
+    #     table_name: str,
+    #     code_fields: List[str],
+    #     query_overrides: dict = {},
+    #     log: bool = False,
+    #     auth_args: Auth = Auth.shared(),
+    #     **query_kwargs
+    # ):
+    #     """TODO: Write some good docs"""
+
+    @staticmethod
     def get_count_by_field(
         table_name: str,
         field: str,
@@ -397,3 +513,92 @@ class Query:
             )
 
         return pd.DataFrame(results)
+
+    @staticmethod
+    def _recursive_execute_composite_aggregations(
+        table_name: str,
+        key_sources_pairs: List[Tuple[str, List[dict]]],
+        batch_size: int = 100,
+        progress: Union[tqdm, None] = None,
+        query_overrides: dict = {},
+        log: bool = False,
+        auth_args: Auth = Auth.shared(),
+        max_pages: Union[int, None] = None,
+        _current_page: int = 1,
+        _prev_results: dict = {},
+        _after_keys: dict = {},
+        **query_kwargs,
+    ):
+        aggregation = Query.execute_fhir_dsl(
+            {
+                "type": "select",
+                "columns": [
+                    {
+                        "type": "elasticsearch",
+                        "aggregations": {
+                            key: {
+                                "composite": {
+                                    "sources": sources,
+                                    "size": batch_size,
+                                    **(
+                                        {"after": _after_keys[key]}
+                                        if key in _after_keys
+                                        else {}
+                                    ),
+                                }
+                            }
+                            for key, sources in key_sources_pairs
+                            if (len(_after_keys) == 0) or (key in _after_keys)
+                        },
+                    }
+                ],
+                "from": [{"table": table_name}],
+                **query_overrides,
+            },
+            auth_args=auth_args,
+            log=log,
+            **query_kwargs,
+        )
+
+        current_results = aggregation.data
+        results = FhirAggregation.reduce_composite_results(
+            _prev_results, current_results
+        )
+
+        if (progress is not None) and (_current_page == 1) and max_pages:
+            progress.reset(max_pages)
+
+        if progress is not None:
+            # Update by count or pages (if max_pages specified)
+            progress.update(
+                1
+                if max_pages
+                else FhirAggregation.count_composite_results(current_results)
+            )
+
+        after_keys = FhirAggregation.find_composite_after_keys(
+            current_results, batch_size
+        )
+
+        if len(after_keys) == 0 or (
+            (max_pages is not None) and (_current_page >= max_pages)
+        ):
+            print(
+                f"Retrieved {FhirAggregation.count_composite_results(results)} results"
+            )
+            return results
+
+        return Query._recursive_execute_composite_aggregations(
+            table_name=table_name,
+            key_sources_pairs=key_sources_pairs,
+            batch_size=batch_size,
+            progress=progress,
+            query_overrides=query_overrides,
+            log=log,
+            auth_args=auth_args,
+            max_pages=max_pages,
+            _current_page=_current_page + 1,
+            _prev_results=results,
+            _after_keys=after_keys,
+            **query_kwargs,
+        )

--- a/phc/easy/query/fhir_aggregation.py
+++ b/phc/easy/query/fhir_aggregation.py
@@ -1,4 +1,5 @@
 from typing import NamedTuple
+from functools import reduce
 
 
 class FhirAggregation(NamedTuple):
@@ -17,3 +18,38 @@ class FhirAggregation(NamedTuple):
             next(filter(lambda c: "aggregations" in c, query["columns"]), None)
             is not None
         )
+
+    @staticmethod
+    def find_composite_after_keys(results: dict, batch_size: int):
+        return {
+            key: value.get("after_key")
+            for key, value in results.items()
+            if value.get("after_key", None) is not None
+            and len(value.get("buckets", [])) == batch_size
+        }
+
+    @staticmethod
+    def reduce_composite_results(prev_results: dict, current_results: dict):
+        keys = set([*prev_results.keys(), *current_results.keys()])
+
+        return {
+            key: {
+                "buckets": [
+                    *get_buckets(key, prev_results),
+                    *get_buckets(key, current_results),
+                ]
+            }
+            for key in keys
+        }
+
+    @staticmethod
+    def count_composite_results(results: dict):
+        return reduce(
+            lambda acc, key: acc + len(results[key]["buckets"]),
+            results.keys(),
+            0,
+        )
+
+
+def get_buckets(key: str, obj: dict):
+    return obj.get(key, {}).get("buckets", [])

--- a/phc/easy/specimen.py
+++ b/phc/easy/specimen.py
@@ -10,6 +10,10 @@ class Specimen(PatientItem):
         return "specimen"
 
     @staticmethod
+    def code_keys():
+        return ["type.coding", "meta.tag", "collection.bodySite.coding"]
+
+    @staticmethod
     def transform_results(df: pd.DataFrame, **expand_args):
         return Frame.expand(
             df,

--- a/tests/test_fhir_aggregation.py
+++ b/tests/test_fhir_aggregation.py
@@ -1,5 +1,29 @@
 from phc.easy.query.fhir_aggregation import FhirAggregation
 
+SAMPLE_COMPOSITE_RESULT = {
+    "meta.tag": {
+        "after_key": {"value": "meta.tag.example-after-key"},
+        "buckets": [
+            {"key": {"value": "meta.tag.first-key"}, "doc_count": 3},
+            {"key": {"value": "meta.tag.second-key"}, "doc_count": 1},
+        ],
+    },
+    "code.coding": {
+        "after_key": {"value": "code.coding.example-after-key"},
+        "buckets": [{"key": {"value": "meta.tag.first-key"}, "doc_count": 3}],
+    },
+    "component.code.coding": {
+        "buckets": [
+            {"key": {"value": "meta.tag.first-key"}, "doc_count": 3},
+            {"key": {"value": "meta.tag.second-key"}, "doc_count": 1},
+        ]
+    },
+    "valueCodeableConcept.coding": {
+        "after_key": {"value": "valueCodeableConcept.coding.example-after-key"},
+        "buckets": [],
+    },
+}
+
 
 def test_is_aggregation_query():
     query = {
@@ -38,3 +62,86 @@ def test_is_not_aggregation_query_with_all_columns():
     }
 
     assert not FhirAggregation.is_aggregation_query(query)
+
+
+def test_find_composite_after_keys():
+    assert FhirAggregation.find_composite_after_keys(
+        SAMPLE_COMPOSITE_RESULT, batch_size=2
+    ) == {"meta.tag": {"value": "meta.tag.example-after-key"}}
+
+
+def test_count_composite_results():
+    assert FhirAggregation.count_composite_results(SAMPLE_COMPOSITE_RESULT) == 5
+
+
+def test_reduce_composite_results_from_start():
+    sample = {
+        "meta.tag": {
+            "after_key": {"value": "meta.tag.example-after-key"},
+            "buckets": [
+                {"key": {"value": "meta.tag.first-example"}, "doc_count": 10},
+                {"key": {"value": "meta.tag.second-example"}, "doc_count": 3},
+            ],
+        }
+    }
+
+    assert FhirAggregation.reduce_composite_results({}, sample) == {
+        "meta.tag": {
+            "buckets": [
+                {"key": {"value": "meta.tag.first-example"}, "doc_count": 10},
+                {"key": {"value": "meta.tag.second-example"}, "doc_count": 3},
+            ]
+        }
+    }
+
+
+def test_reduce_composite_results():
+    previous = {
+        "meta.tag": {
+            "after_key": {"value": "meta.tag.example-after-key"},
+            "buckets": [
+                {"key": {"value": "meta.tag.first-example"}, "doc_count": 10},
+                {"key": {"value": "meta.tag.second-example"}, "doc_count": 3},
+            ],
+        },
+        "code.coding": {
+            "after_key": {"value": "code.coding.example-after-key"},
+            "buckets": [
+                {"key": {"value": "code.coding.first-example"}, "doc_count": 7},
+                {
+                    "key": {"value": "code.coding.second-example"},
+                    "doc_count": 21,
+                },
+            ],
+        },
+    }
+
+    current = {
+        "meta.tag": {
+            "after_key": {"value": "meta.tag.example-next-after-key"},
+            "buckets": [
+                {"key": {"value": "meta.tag.third-example"}, "doc_count": 2},
+                {"key": {"value": "meta.tag.fourth-example"}, "doc_count": 1},
+            ],
+        }
+    }
+
+    assert FhirAggregation.reduce_composite_results(previous, current) == {
+        "meta.tag": {
+            "buckets": [
+                {"key": {"value": "meta.tag.first-example"}, "doc_count": 10},
+                {"key": {"value": "meta.tag.second-example"}, "doc_count": 3},
+                {"key": {"value": "meta.tag.third-example"}, "doc_count": 2},
+                {"key": {"value": "meta.tag.fourth-example"}, "doc_count": 1},
+            ]
+        },
+        "code.coding": {
+            "buckets": [
+                {"key": {"value": "code.coding.first-example"}, "doc_count": 7},
+                {
+                    "key": {"value": "code.coding.second-example"},
+                    "doc_count": 21,
+                },
+            ]
+        },
+    }


### PR DESCRIPTION
This PR includes the generic functionality for executing composite aggregations (which is now used by `get_count_by_field`) as well as the high-level `get_codes` for specific entities (Observation, Procedure, etc.).

Examples below are from the available "BRCA" data set.

Example 1: Get observation codes for a specific patient
```python
phc.Observation.get_codes(patient_id="<example-patient-id>")
```

Result 1:
```
   doc_count                            system                                  code                                     display        field
0        1.0                  http://loinc.org                               21893-3  Regional lymph nodes positive [#] Specimen  code.coding
1        1.0                  http://loinc.org                               21975-8                        Date of Last Contact  code.coding
2        1.0                  http://loinc.org                               63931-0                           Date of Diagnosis  code.coding
3        1.0                  http://loinc.org                               85337-4                    Estrogen Receptor Status  code.coding
4        1.0                  http://loinc.org                               85339-0                Progesterone Receptor Status  code.coding
0        5.0  http://********.com/fhir/dataset                           <hidden-id>                                        None     meta.tag
```

Example 2: Get all procedure codes used since 2010
```python
phc.Procedure.get_codes(query_overrides={
    "where": {
        "type": "elasticsearch",
        "query": {
            "range": {
                "performedDateTime": {
                    "gte": "2010-01-01"
                }
            }
        }
    }
})
```

Result 2:
```
    doc_count                            system                                  code                               display            field
0           2  http://hl7.org/fhir/sid/icd-9-cm                                 77.45                       Biopsy of femur      code.coding
1           2            http://snomed.info/sct                            1220629018                  Breast biopsy sample      code.coding
2           6            http://snomed.info/sct                             137540019                              PET scan      code.coding
3          84            http://snomed.info/sct                             172043006                     simple mastectomy      code.coding
4           2            http://snomed.info/sct                             287549000  Percutaneous needle lymphatic biopsy      code.coding
5           2            http://snomed.info/sct                             361748014                         MRI of breast      code.coding
6         100            http://snomed.info/sct                             392021009                            lumpectomy      code.coding
7          62            http://snomed.info/sct                             392090004                                 other      code.coding
8           2            http://snomed.info/sct                              40016001       Prophylactic treatment of femur      code.coding
9         191            http://snomed.info/sct                             406505007           modified radical mastectomy      code.coding
10          2            http://snomed.info/sct                             418857002          US scan and biopsy of breast      code.coding
0         455  http://********.com/fhir/dataset                           <hidden-id>                                  None         meta.tag
0         437            http://snomed.info/sct                             387713003                    Surgical procedure  category.coding
```