### PR TITLE
Add links for `0.15.0` and `0.16.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added most of remaining FSS entities: 
+- Added most of remaining FSS entities:
   - AuditEvent
   - CarePlan
   - DiagnosticReport
@@ -253,6 +253,8 @@ phc.Observation.get_data_frame(patient_id="<id>", query_overrides={
 - Added the `phc.services.Files` submodule that provides actions for files in PHC projects.
 - Added the `phc.services.Cohorts` submodule that provides actions for files in PHC cohorts.
 
+[0.16.0]: https://github.com/lifeomic/phc-sdk-py/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/lifeomic/phc-sdk-py/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/lifeomic/phc-sdk-py/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/lifeomic/phc-sdk-py/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/lifeomic/phc-sdk-py/compare/v0.12.2...v0.13.0


### PR DESCRIPTION
Was reviewing the changelogs that are aggregated here: https://docs.us.lifeomic.com/release-notes/phc-sdk-py/

Will add version links for the diffs.