### PR TITLE
Add max_pages for easy queries (Query/Item/PatientItem)

### DIFF
--- a/phc/easy/item.py
+++ b/phc/easy/item.py
@@ -45,6 +45,7 @@ class Item:
         cls,
         all_results: bool = False,
         raw: bool = False,
+        max_pages: Union[int, None] = None,
         query_overrides: dict = {},
         auth_args=Auth.shared(),
         ignore_cache: bool = False,
@@ -61,6 +62,9 @@ class Item:
         raw : bool = False
             If raw, then values will not be expanded (useful for manual
             inspection if something goes wrong)
+
+        max_pages : int
+            The number of pages to retrieve (useful if working with tons of records)
 
         query_overrides : dict = {}
             Override any part of the elasticsearch FHIR query
@@ -105,6 +109,7 @@ class Item:
             query_overrides,
             auth_args,
             ignore_cache,
+            max_pages=max_pages,
             log=log,
         )
 

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -28,6 +28,7 @@ class PatientItem(Item):
         raw: bool = False,
         patient_id: Union[None, str] = None,
         patient_ids: List[str] = [],
+        max_pages: Union[int, None] = None,
         query_overrides: dict = {},
         auth_args=Auth.shared(),
         ignore_cache: bool = False,
@@ -50,6 +51,9 @@ class PatientItem(Item):
 
         patient_ids : List[str]
             Find records for given patient_ids
+
+        max_pages : int
+            The number of pages to retrieve (useful if working with tons of records)
 
         query_overrides : dict = {}
             Override any part of the elasticsearch FHIR query
@@ -96,6 +100,7 @@ class PatientItem(Item):
             ignore_cache,
             patient_id=patient_id,
             patient_ids=patient_ids,
+            max_pages=max_pages,
             patient_key=cls.patient_key(),
             log=log,
             patient_id_prefixes=cls.patient_id_prefixes(),

--- a/phc/easy/query/fhir_dsl.py
+++ b/phc/easy/query/fhir_dsl.py
@@ -33,6 +33,8 @@ def recursive_execute_fhir_dsl(
     progress: Union[None, tqdm] = None,
     auth_args: Auth = Auth.shared(),
     callback: Union[Callable[[Any, bool], None], None] = None,
+    max_pages: Union[int, None] = None,
+    _current_page: int = 1,
     _scroll_id: str = "true",
     _prev_hits: List = [],
 ):
@@ -54,7 +56,11 @@ def recursive_execute_fhir_dsl(
     if progress:
         progress.update(current_result_count)
 
-    is_last_batch = current_result_count == 0 or scroll is False
+    is_last_batch = (
+        (current_result_count == 0)
+        or (scroll is False)
+        or ((max_pages is not None) and (_current_page >= max_pages))
+    )
     results = [] if callback else [*_prev_hits, *current_results]
 
     if callback and not is_last_batch:
@@ -73,6 +79,8 @@ def recursive_execute_fhir_dsl(
         progress=progress,
         auth_args=auth_args,
         callback=callback,
+        max_pages=max_pages,
+        _current_page=_current_page + 1,
         _scroll_id=_scroll_id,
         _prev_hits=results,
     )


### PR DESCRIPTION
Closes #53

Example:

```python
phc.Observation.get_data_frame(all_results=True, max_pages=2)
# 18000/50145 [00:00<16:40, 40.27it/s]
# Retrieved 18000/50145 results
# ...
```

Note that this will not auto-cache since the results are not unique to the query (i.e. a different `max_pages` value would produce different results).