### PR TITLE
Merge patient_ids with 'must' FSS query

### DIFF
--- a/phc/easy/query/fhir_dsl_query.py
+++ b/phc/easy/query/fhir_dsl_query.py
@@ -8,6 +8,7 @@ FHIR_WHERE = lens.Get("where", {})
 FHIR_WHERE_TYPE = FHIR_WHERE.Get("type", "")
 FHIR_SIMPLE_QUERY = FHIR_WHERE.Get("query", {})
 FHIR_BOOL_QUERY = FHIR_SIMPLE_QUERY.Get("bool", {})
+FHIR_BOOL_MUST_QUERY = FHIR_BOOL_QUERY.Get("must", [])
 
 
 @curry
@@ -42,6 +43,11 @@ def and_query_clause(query: dict, query_clause: dict):
         "should" in bool_keys
     ):
         return FHIR_SIMPLE_QUERY.modify(and_query_clause_terms(query_clause))(
+            query
+        )
+
+    if len(bool_keys) == 1 and "must" in bool_keys:
+        return FHIR_BOOL_MUST_QUERY.modify(lambda must: [*must, query_clause])(
             query
         )
 

--- a/tests/test_fhir_dsl_query.py
+++ b/tests/test_fhir_dsl_query.py
@@ -65,6 +65,35 @@ def test_add_patient_id_with_query_term():
     }
 
 
+def test_add_patient_id_with_bool_must_query():
+    result = build_query(
+        {
+            "where": {
+                "type": "elasticsearch",
+                "query": {
+                    "bool": {"must": [{"term": {"gender.keyword": "male"}}]}
+                },
+            }
+        },
+        patient_ids=["a"],
+        patient_key="id",
+    )
+
+    assert result == {
+        "where": {
+            "type": "elasticsearch",
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"gender.keyword": "male"}},
+                        {"terms": {"id.keyword": ["Patient/a", "a"]}},
+                    ],
+                }
+            },
+        }
+    }
+
+
 def test_add_patient_id_with_bool_should_query():
     result = build_query(
         {


### PR DESCRIPTION
Closes #57

Example:

```python
phc.Observation.get_data_frame(patient_id="41e6a5bc-7b8a-4434-b38b-0da652d6364e", query_overrides={
    "where": {
        "type": "elasticsearch",
        "query": {
            "bool": {
                "must": [
                    {"term": {"code.coding.system.keyword": "http://loinc.org"}},
                    {"term": {"code.coding.code.keyword": "21975-8"}}
                ]
            }
        }
    }
}, log=True)
```

This call produces the following query:
```json
{
    "type": "select",
    "columns": "*",
    "from": [
        {
            "table": "observation"
        }
    ],
    "where": {
        "type": "elasticsearch",
        "query": {
            "bool": {
                "must": [
                    {
                        "term": {
                            "code.coding.system.keyword": "http://loinc.org"
                        }
                    },
                    {
                        "term": {
                            "code.coding.code.keyword": "21975-8"
                        }
                    },
                    {
                        "terms": {
                            "subject.reference.keyword": [
                                "Patient/41e6a5bc-7b8a-4434-b38b-0da652d6364e",
                                "41e6a5bc-7b8a-4434-b38b-0da652d6364e"
                            ]
                        }
                    }
                ]
            }
        }
    }
}
```