### PR TITLE
Fix paging issues with large records

### DIFF
--- a/phc/easy/item.py
+++ b/phc/easy/item.py
@@ -45,6 +45,7 @@ class Item:
         cls,
         all_results: bool = False,
         raw: bool = False,
+        page_size: Union[int, None] = None,
         max_pages: Union[int, None] = None,
         query_overrides: dict = {},
         auth_args=Auth.shared(),
@@ -62,6 +63,9 @@ class Item:
         raw : bool = False
             If raw, then values will not be expanded (useful for manual
             inspection if something goes wrong)
+
+        page_size : int
+            The number of records to fetch per page
 
         max_pages : int
             The number of pages to retrieve (useful if working with tons of records)
@@ -109,6 +113,7 @@ class Item:
             query_overrides,
             auth_args,
             ignore_cache,
+            page_size=page_size,
             max_pages=max_pages,
             log=log,
         )

--- a/phc/easy/patient_item.py
+++ b/phc/easy/patient_item.py
@@ -28,6 +28,7 @@ class PatientItem(Item):
         raw: bool = False,
         patient_id: Union[None, str] = None,
         patient_ids: List[str] = [],
+        page_size: Union[int, None] = None,
         max_pages: Union[int, None] = None,
         query_overrides: dict = {},
         auth_args=Auth.shared(),
@@ -51,6 +52,9 @@ class PatientItem(Item):
 
         patient_ids : List[str]
             Find records for given patient_ids
+
+        page_size : int
+            The number of records to fetch per page
 
         max_pages : int
             The number of pages to retrieve (useful if working with tons of records)
@@ -100,6 +104,7 @@ class PatientItem(Item):
             ignore_cache,
             patient_id=patient_id,
             patient_ids=patient_ids,
+            page_size=page_size,
             max_pages=max_pages,
             patient_key=cls.patient_key(),
             log=log,

--- a/phc/easy/patients/__init__.py
+++ b/phc/easy/patients/__init__.py
@@ -23,6 +23,10 @@ class Patient(Item):
     def transform_results(data_frame: pd.DataFrame, **expand_args):
         args = {
             **expand_args,
+            "code_columns": [
+                *expand_args.get("code_columns", []),
+                "maritalStatus",
+            ],
             "custom_columns": [
                 *expand_args.get("custom_columns", []),
                 ("address", expand_address_column),

--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -9,6 +9,7 @@ from phc.easy.query.ga4gh import recursive_execute_ga4gh
 from phc.easy.query.fhir_dsl_query import build_query
 from phc.easy.query.fhir_dsl import (
     MAX_RESULT_SIZE,
+    DEFAULT_SCROLL_SIZE,
     recursive_execute_fhir_dsl,
     execute_single_fhir_dsl,
     tqdm,
@@ -51,15 +52,7 @@ class Query:
         fhir = Fhir(auth.session())
 
         response = fhir.execute_es(
-            auth.project_id,
-            {
-                **query,
-                "limit": [
-                    {"type": "number", "value": 0},
-                    {"type": "number", "value": 1},
-                ],
-            },
-            scroll="true",
+            auth.project_id, build_query(query, page_size=1), scroll="true",
         )
 
         return response.data["hits"]["total"]["value"]
@@ -145,10 +138,7 @@ class Query:
                             {"type": "number", "value": 0},
                             # Make window size smaller than maximum to reduce
                             # pressure on API
-                            {
-                                "type": "number",
-                                "value": int(MAX_RESULT_SIZE * 0.9),
-                            },
+                            {"type": "number", "value": DEFAULT_SCROLL_SIZE},
                         ],
                         **query,
                     },

--- a/phc/easy/query/fhir_dsl.py
+++ b/phc/easy/query/fhir_dsl.py
@@ -1,12 +1,21 @@
 from typing import Any, Callable, List, Union
+from lenses import lens
 
+import math
 import pandas as pd
 
 from phc.easy.auth import Auth
 from phc.services import Fhir
 from phc.easy.util import with_progress, tqdm
+from phc.easy.query.fhir_dsl_query import (
+    MAX_RESULT_SIZE,
+    DEFAULT_SCROLL_SIZE,
+    get_limit,
+    update_limit,
+    build_query,
+)
 
-MAX_RESULT_SIZE = 10000
+MAX_RETRY_BACKOFF = 3
 
 
 def query_allows_scrolling(query):
@@ -19,12 +28,54 @@ def query_allows_scrolling(query):
 
 
 def execute_single_fhir_dsl(
-    query: dict, scroll_id: str = "", auth_args: Auth = Auth.shared()
+    query: dict,
+    scroll_id: str = "",
+    retry_backoff: bool = False,
+    auth_args: Auth = Auth.shared(),
+    _retry_time: int = 1,
 ):
     auth = Auth(auth_args)
     fhir = Fhir(auth.session())
 
-    return fhir.execute_es(auth.project_id, query, scroll_id)
+    if _retry_time >= MAX_RETRY_BACKOFF or retry_backoff is False:
+        return fhir.dsl(auth.project_id, query, scroll_id)
+
+    try:
+        return fhir.dsl(auth.project_id, query, scroll_id)
+    except Exception as err:
+        if "Internal server error" not in str(err):
+            raise err
+
+        if _retry_time == 1:
+            # Base first retry attempt on record count
+            record_count = fhir.dsl(
+                auth.project_id, build_query(query, page_size=1), scroll="true"
+            ).data["hits"]["total"]["value"]
+
+            def backoff_limit(limit: int):
+                return min(
+                    (get_limit(query) or DEFAULT_SCROLL_SIZE) / 2,
+                    math.pow(record_count, 0.85),
+                )
+
+        else:
+
+            def backoff_limit(limit: int):
+                return math.pow(limit, 0.85)
+
+        new_query = update_limit(query, backoff_limit)
+
+        print(
+            f"Received server error. Retrying with page_size={get_limit(new_query)}"
+        )
+
+        return execute_single_fhir_dsl(
+            new_query,
+            scroll_id=scroll_id,
+            retry_backoff=True,
+            auth_args=auth_args,
+            _retry_time=_retry_time + 1,
+        )
 
 
 def recursive_execute_fhir_dsl(
@@ -38,10 +89,13 @@ def recursive_execute_fhir_dsl(
     _scroll_id: str = "true",
     _prev_hits: List = [],
 ):
+    will_scroll = query_allows_scrolling(query) and scroll
+
     response = execute_single_fhir_dsl(
         query,
-        _scroll_id if query_allows_scrolling(query) and scroll else "",
-        auth_args,
+        scroll_id=_scroll_id if will_scroll else "",
+        retry_backoff=will_scroll,
+        auth_args=auth_args,
     )
 
     is_first_iteration = _scroll_id == "true"

--- a/phc/easy/query/fhir_dsl.py
+++ b/phc/easy/query/fhir_dsl.py
@@ -37,13 +37,14 @@ def execute_single_fhir_dsl(
     auth = Auth(auth_args)
     fhir = Fhir(auth.session())
 
-    if _retry_time >= MAX_RETRY_BACKOFF or retry_backoff is False:
-        return fhir.dsl(auth.project_id, query, scroll_id)
-
     try:
         return fhir.dsl(auth.project_id, query, scroll_id)
     except Exception as err:
-        if "Internal server error" not in str(err):
+        if (
+            (_retry_time >= MAX_RETRY_BACKOFF)
+            or (retry_backoff is False)
+            or ("Internal server error" not in str(err))
+        ):
             raise err
 
         if _retry_time == 1:

--- a/phc/easy/query/fhir_dsl_query.py
+++ b/phc/easy/query/fhir_dsl_query.py
@@ -22,7 +22,7 @@ FHIR_LIMIT = lens.Get(
 
 
 def get_limit(query: dict):
-    return lens.Get("limit", [])[1].Get("value", None).get()(query)
+    return lens.Get("limit", [{}, {}])[1].Get("value", None).get()(query)
 
 
 def update_limit(query: dict, update: Callable[[int], int]):
@@ -111,7 +111,31 @@ def build_query(
     patient_id_prefixes: List[str] = ["Patient/"],
     page_size: Union[int, None] = None,
 ):
-    "Build query with patient_ids"
+    """Build query with various options
+
+    Attributes
+    ----------
+    query : dict
+        The base FSS query
+
+    patient_id : str
+        Adds where clause for a single patient (will be merged with
+        patient_ids if both supplied)
+
+    patient_ids : List[str]
+        Adds where clause for multiple patients
+
+    patient_key : str
+        The column that associates this table's records to a patient
+
+    patient_id_prefixes : str
+        Adds a prefix to patient_id values (e.g.
+        "Patient/0a20d90f-c73c-4149-953d-7614ce7867f" as well as
+        "0a20d90f-c73c-4149-953d-7614ce7867f")
+
+    page_size: int
+        The number of records to fetch per page
+    """
 
     return pipe(
         query,

--- a/phc/easy/query/fhir_dsl_query.py
+++ b/phc/easy/query/fhir_dsl_query.py
@@ -1,14 +1,32 @@
-from toolz import pipe, identity, curry
-from typing import List, Union
+from toolz import pipe, identity, curry, compose
+from typing import List, Union, Callable
 from lenses import lens
 
 from phc.easy.util import add_prefixes
+
+MAX_RESULT_SIZE = 10000
+DEFAULT_SCROLL_SIZE = int(MAX_RESULT_SIZE * 0.9)
 
 FHIR_WHERE = lens.Get("where", {})
 FHIR_WHERE_TYPE = FHIR_WHERE.Get("type", "")
 FHIR_SIMPLE_QUERY = FHIR_WHERE.Get("query", {})
 FHIR_BOOL_QUERY = FHIR_SIMPLE_QUERY.Get("bool", {})
 FHIR_BOOL_MUST_QUERY = FHIR_BOOL_QUERY.Get("must", [])
+FHIR_LIMIT = lens.Get(
+    "limit",
+    [
+        {"type": "number", "value": 0},
+        {"type": "number", "value": DEFAULT_SCROLL_SIZE},
+    ],
+)[1]["value"]
+
+
+def get_limit(query: dict):
+    return lens.Get("limit", [])[1].Get("value", None).get()(query)
+
+
+def update_limit(query: dict, update: Callable[[int], int]):
+    return FHIR_LIMIT.modify(compose(int, update))(query)
 
 
 @curry
@@ -78,12 +96,20 @@ def _patient_ids_adder(
     )
 
 
+def _limit_adder(page_size: Union[int, None]):
+    if page_size is None:
+        return identity
+
+    return FHIR_LIMIT.set(page_size)
+
+
 def build_query(
     query: dict,
     patient_id: Union[str, None] = None,
     patient_ids: List[str] = [],
     patient_key: str = "subject.reference",
     patient_id_prefixes: List[str] = ["Patient/"],
+    page_size: Union[int, None] = None,
 ):
     "Build query with patient_ids"
 
@@ -95,4 +121,5 @@ def build_query(
             patient_key=patient_key,
             patient_id_prefixes=patient_id_prefixes,
         ),
+        _limit_adder(page_size),
     )

--- a/tests/test_fhir_dsl_query.py
+++ b/tests/test_fhir_dsl_query.py
@@ -1,7 +1,7 @@
 import math
 
 from nose.tools import raises
-from phc.easy.query.fhir_dsl_query import build_query, update_limit
+from phc.easy.query.fhir_dsl_query import build_query, update_limit, get_limit
 
 
 def test_update_limit_with_base_query():
@@ -214,3 +214,19 @@ def test_add_single_patient_id_with_prefix():
             },
         }
     }
+
+
+def test_get_limit():
+    assert get_limit({}) == None
+
+    assert (
+        get_limit(
+            {
+                "limit": [
+                    {"type": "number", "value": 0},
+                    {"type": "number", "value": 100},
+                ]
+            }
+        )
+        == 100
+    )


### PR DESCRIPTION
Sometimes, records are so large that API Gateway rejects the results even though our back-end systems don't otherwise error. Therefore, I've designed a strategy and retries the request with a `total_record_count^(0.85)` or half the existing limit (whichever is smaller) batch size. On subsequent retries (up to 3), it will continue the decay with `last_limit^(0.85)` records per batch.

Additionally, this PR includes the option of explicitly passing `page_size` to FSS query calls. Example:

```python
phc.Patient.get_data_frame(all_results=True, page_size=1000)
```

Note: I initially reviewed the error with @tdstein.