### PR TITLE
Revamp expanded columns

### DIFF
--- a/phc/easy/codeable.py
+++ b/phc/easy/codeable.py
@@ -14,8 +14,7 @@ from phc.easy.util import (
 
 def system_to_column(system):
     "Convert system name (potentially URL) to a readable column name"
-    (new_string, _) = re.subn(r"https?:\/\/", "", system)
-    return new_string  # .replace(".", "_").replace("/", "_")
+    return re.subn(r"https?:\/\/", "", system)[0]
 
 
 def value_string_to_dict(codeable):

--- a/phc/easy/codeable.py
+++ b/phc/easy/codeable.py
@@ -15,7 +15,7 @@ from phc.easy.util import (
 def system_to_column(system):
     "Convert system name (potentially URL) to a readable column name"
     (new_string, _) = re.subn(r"https?:\/\/", "", system)
-    return new_string.replace(".", "_").replace("/", "_")
+    return new_string  # .replace(".", "_").replace("/", "_")
 
 
 def value_string_to_dict(codeable):
@@ -23,12 +23,30 @@ def value_string_to_dict(codeable):
     return {system_to_column(codeable["url"]): codeable["valueString"]}
 
 
+def merge_codeable_and_prefix(codeable, prefix):
+    if isinstance(codeable, dict):
+        return prefix_dict_keys(codeable, prefix)
+    else:
+        return concat_dicts(codeable, prefix)
+
+
 def get_value_codeable_concept_items(concept):
     "Extracts dictionaries in a valueCodeableConcept"
     base_concept = without_keys(concept, ["coding"])
 
+    if "coding" not in concept:
+        return [base_concept]
+
     return [
-        {**base_concept, **coding_value} for coding_value in concept["coding"]
+        {
+            **base_concept,
+            **(
+                merge_codeable_and_prefix(
+                    *flatten_and_find_prefix(coding_value, "coding")
+                )
+            ),
+        }
+        for coding_value in concept["coding"]
     ]
 
 
@@ -46,7 +64,14 @@ def flatten_nested_dicts(codeable_dict):
             return [
                 *acc,
                 *[
-                    {**base_dict, **result}
+                    {
+                        **base_dict,
+                        **(
+                            merge_codeable_and_prefix(
+                                *flatten_and_find_prefix(result, key)
+                            )
+                        ),
+                    }
                     for result in func(codeable_dict[key])
                 ],
             ]
@@ -77,7 +102,7 @@ def flatten_and_find_prefix(codeable_dict, prefix):
         return (
             flatten_nested_dicts(without_keys(codeable_dict, ["url"])),
             join_underscore(
-                [prefix, system_to_column(codeable_dict["url"]) + "_"]
+                [prefix, "url_", system_to_column(codeable_dict["url"]) + "_"]
             ),
         )
 
@@ -85,7 +110,11 @@ def flatten_and_find_prefix(codeable_dict, prefix):
         return (
             without_keys(codeable_dict, ["system"]),
             join_underscore(
-                [prefix, system_to_column(codeable_dict["system"]) + "_"]
+                [
+                    prefix,
+                    "system_",
+                    system_to_column(codeable_dict["system"]) + "_",
+                ]
             ),
         )
 
@@ -93,7 +122,7 @@ def flatten_and_find_prefix(codeable_dict, prefix):
         types = codeable_dict["type"]["coding"]
         return (
             [{**t, **without_keys(codeable_dict, ["type"])} for t in types],
-            prefix,
+            join_underscore(["type", "coding", prefix]),
         )
 
     return (codeable_dict, prefix)
@@ -130,11 +159,17 @@ def generic_codeable_to_dict(codeable, prefix=""):
     # if len(keys) == 1 and 'url' in codeable:
     #     return prefixer({key: system_to_column(codeable[key]) + '+'})
 
-    return prefixer(
+    result = prefixer(
         concat_dicts(
             [generic_codeable_to_dict(v, k) for k, v in codeable.items()]
         )
     )
+
+    import json
+
+    print(json.dumps(result, indent=4))
+
+    return result
 
 
 class Codeable:

--- a/tests/test_codeable.py
+++ b/tests/test_codeable.py
@@ -5,8 +5,8 @@ from phc.easy.codeable import generic_codeable_to_dict, Codeable
 
 def test_parsing_lat_long_extension():
     expected = {
-        "hl7_org_fhir_StructureDefinition_geolocation__latitude__valueDecimal": -71.058706,
-        "hl7_org_fhir_StructureDefinition_geolocation__longitude__valueDecimal": 42.42938,
+        "url__hl7.org/fhir/StructureDefinition/geolocation__extension_url__latitude__valueDecimal": -71.058706,
+        "url__hl7.org/fhir/StructureDefinition/geolocation__extension_url__longitude__valueDecimal": 42.42938,
     }
 
     assert (
@@ -52,11 +52,11 @@ def test_parsing_simple_meta_value():
 
     assert generic_codeable_to_dict(input_dict) == {
         "tag_lastUpdated": "2019-08-13T17:47:18.957Z",
-        "tag_lifeomic_com_fhir_group__code": "group-code-id",
-        "tag_lifeomic_com_fhir_dataset__code": "dataset-code-id",
-        "tag_lifeomic_com_fhir_dataset__code_1": "dataset-second-code-id",
-        "tag_lifeomic_com_fhir_source__code": "LifeOmic Consent",
-        "tag_lifeomic_com_fhir_questionnaire-type__code": "consent-form",
+        "tag_system__lifeomic.com/fhir/group__code": "group-code-id",
+        "tag_system__lifeomic.com/fhir/dataset__code": "dataset-code-id",
+        "tag_system__lifeomic.com/fhir/dataset__code_1": "dataset-second-code-id",
+        "tag_system__lifeomic.com/fhir/source__code": "LifeOmic Consent",
+        "tag_system__lifeomic.com/fhir/questionnaire-type__code": "consent-form",
     }
 
 
@@ -68,7 +68,7 @@ def test_parsing_system_value():
         },
         prefix="extension",
     ) == {
-        "extension_lifeomic_com_fhir_consent-form-id__value": "default-project-consent-form"
+        "extension_system__lifeomic.com/fhir/consent-form-id__value": "default-project-consent-form"
     }
 
 
@@ -103,12 +103,27 @@ def test_parsing_extension_with_race():
     ]
 
     assert generic_codeable_to_dict(input_dict) == {
-        "hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__text": "race",
-        "hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__code": "2106-3",
-        "hl7_org_fhir_StructureDefinition_us-core-race__hl7_org_fhir_v3_Race__display": "white",
-        "hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__text": "ethnicity",
-        "hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__code": "2186-5",
-        "hl7_org_fhir_StructureDefinition_us-core-ethnicity__hl7_org_fhir_v3_Ethnicity__display": "not hispanic or latino",
+        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_text": "race",
+        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Race__code": "2106-3",
+        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Race__display": "white",
+        "url__hl7.org/fhir/StructureDefinition/us-core-ethnicity__valueCodeableConcept_text": "ethnicity",
+        "url__hl7.org/fhir/StructureDefinition/us-core-ethnicity__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Ethnicity__code": "2186-5",
+        "url__hl7.org/fhir/StructureDefinition/us-core-ethnicity__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Ethnicity__display": "not hispanic or latino",
+    }
+
+
+def test_parsing_extension_without_coding():
+    input_dict = [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
+            "valueCodeableConcept": {
+                "text": "American Indian or Alaska Native"
+            },
+        }
+    ]
+
+    assert generic_codeable_to_dict(input_dict) == {
+        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_text": "American Indian or Alaska Native"
     }
 
 
@@ -124,9 +139,12 @@ def test_parsing_anonymous_identifier():
         }
     ]
 
+    # NOTE: There's not much we can do to show the underlying structure since
+    # type is really being applied to the value. So, when in conflict, we'll opt
+    # to make more readable columns.
     assert generic_codeable_to_dict(input_dict) == {
-        "hl7_org_fhir_v2_0203__code": "ANON",
-        "hl7_org_fhir_v2_0203__value": "LO-AR-A251",
+        "type_coding_system__hl7.org/fhir/v2/0203__code": "ANON",
+        "type_coding_system__hl7.org/fhir/v2/0203__value": "LO-AR-A251",
     }
 
 
@@ -141,7 +159,7 @@ def test_parsing_basic_meta_value():
     }
 
     assert generic_codeable_to_dict(input_dict) == {
-        "tag_lifeomic_com_fhir_dataset__code": "dataset-code"
+        "tag_system__lifeomic.com/fhir/dataset__code": "dataset-code"
     }
 
 


### PR DESCRIPTION
Commit:
> The columns now reflect the location of the value in the JSON. I hate to
change the column names from under those using the SDK, but we've
received feedback that it's hard to tell how to read these column names.
>
> The minor fix is when a valueCodeableConcept does not have coding
values.

Check out the tests for the full example set, but here's one in particular to show how the columns relate to the data:

```python
def test_parsing_extension_with_race():
    input_dict = [
        {
            "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
            "valueCodeableConcept": {
                "text": "race",
                "coding": [
                    {
                        "code": "2106-3",
                        "system": "http://hl7.org/fhir/v3/Race",
                        "display": "white",
                    }
                ],
            },
        },
        {
            "url": "http://hl7.org/fhir/StructureDefinition/us-core-ethnicity",
            "valueCodeableConcept": {
                "text": "ethnicity",
                "coding": [
                    {
                        "code": "2186-5",
                        "system": "http://hl7.org/fhir/v3/Ethnicity",
                        "display": "not hispanic or latino",
                    }
                ],
            },
        },
    ]

    assert generic_codeable_to_dict(input_dict) == {
        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_text": "race",
        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Race__code": "2106-3",
        "url__hl7.org/fhir/StructureDefinition/us-core-race__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Race__display": "white",
        "url__hl7.org/fhir/StructureDefinition/us-core-ethnicity__valueCodeableConcept_text": "ethnicity",
        "url__hl7.org/fhir/StructureDefinition/us-core-ethnicity__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Ethnicity__code": "2186-5",
        "url__hl7.org/fhir/StructureDefinition/us-core-ethnicity__valueCodeableConcept_coding_system__hl7.org/fhir/v3/Ethnicity__display": "not hispanic or latino",
    }
```