### PR TITLE
Get Codes: Employ multiple queries to report accurate codes

### DIFF
--- a/phc/easy/item.py
+++ b/phc/easy/item.py
@@ -1,7 +1,6 @@
-from typing import Union, List
+from typing import List, Optional, Union
 
 import pandas as pd
-
 from phc.easy.auth import Auth
 from phc.easy.query import Query
 from phc.easy.util import without_keys
@@ -119,10 +118,16 @@ class Item:
         )
 
     @classmethod
-    def get_codes(cls, exclude_meta_tag=True, **kwargs):
+    def get_codes(
+        cls,
+        display_query: Optional[str] = None,
+        sample_size: Optional[int] = None,
+        exclude_meta_tag=True,
+        **kwargs,
+    ):
         """Find all codes
 
-        See possible argments for :func:`~phc.easy.query.Query.get_codes`
+        See possible argments for `phc.easy.query.Query.get_codes`
 
         Examples
         --------
@@ -142,6 +147,7 @@ class Item:
             ]
 
         return Query.get_codes(
+            display_query=display_query,
             table_name=cls.table_name(),
             code_fields=code_fields,
             **without_keys(kwargs, ["code_fields"]),

--- a/tests/test_easy_util.py
+++ b/tests/test_easy_util.py
@@ -1,10 +1,11 @@
 from phc.easy.util import (
+    add_prefixes,
     concat_dicts,
+    defaultprop,
+    extract_codes,
     join_underscore,
     prefix_dict_keys,
     without_keys,
-    defaultprop,
-    add_prefixes,
 )
 
 
@@ -58,6 +59,47 @@ def test_add_prefixes():
         "Patient/b",
         "Patient/c",
     ]
+
+
+# extract codes
+
+
+def test_extract_codes():
+    samples = [
+        {
+            "code": {
+                "coding": [
+                    {
+                        "code": "55233-1",
+                        "system": "http://loinc.org",
+                        "display": "Genetic analysis master panel",
+                    }
+                ]
+            },
+            "meta": {"lastUpdated": "2019-10-11T18:20:35.414Z", "tag": []},
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "code": "unknown",
+                        "system": "http://foundationmedicine.com",
+                        "display": "Foundation - Unknown",
+                    }
+                ]
+            },
+        }
+    ]
+
+    results = extract_codes(
+        samples,
+        "master",
+        ["meta.tag", "code.coding", "valueCodeableConcept.coding"],
+    )
+
+    assert len(results) == 1
+    assert results.iloc[0].to_dict() == {
+        **samples[0]["code"]["coding"][0],
+        "field": "code.coding",
+    }
 
 
 # defaultprop


### PR DESCRIPTION
**API:** `phc.Query.get_codes()`
(e.g. `phc.Observation.get_codes()`)

### Current Limitations ⚠️ 

Here are the current limitations of the FSS API:

We can get aggregates of arbitrary fields on a given record (e.g. `code.coding.display` or `code.coding.system` on an `Observation`), but when we attempt to do an aggregate across multiple fields (e.g to grab the codes of an Observation including the system, code, and display) there is no way to associate the fields. Instead, the SDK was previously returning all permutations of the attributes which is clearly incorrect. There is a deprecated API that contained the rollup code values of a given table, but it is going away.

### SDK Approach 🆕 

In light of these limitations, the SDK will take the following approach as the best stop gap.

1) If no `display` value is being queried, return a data frame of the top display values sorted by the occurence count in the table. This does mean there can be multiple codes for a given display value, but it will at least be human readable.

Example:
```
    doc_count                       display                        field
0      1094.0          Date of Last Contact                  code.coding
1      1094.0             Date of Diagnosis                  code.coding
2      1048.0      Estrogen Receptor Status                  code.coding
3      1047.0  Progesterone Receptor Status                  code.coding
5       919.0      HER2/neu receptor status                  code.coding
6       144.0   Date of Disease Progression                  code.coding
8        48.0              Body temperature                  code.coding
9        48.0          Body weight Measured                  code.coding
10       48.0                   Body height                  code.coding
11       45.0          Foundation - Unknown  valueCodeableConcept.coding
12       34.0                           BUN                  code.coding
13       34.0                    Creatinine                  code.coding
14       34.0                     Platelets                  code.coding
15       12.0            Foundation - Known  valueCodeableConcept.coding
16       10.0                  Consult note                  code.coding
```

2) If a `display` is being queried (with case-insensitive match), we'll do more work for the user. We perform the same above aggregation, but filtered with an FSS `match` clause and then locally filtered (since Elasticsearch returns the records instead of just the codes). These display values can then be used to pull the full records to parse out the codes in each record. We use the `doc_count` to find the maximum record count needed to pull (e.g. `1094 + 1094 + 144` in the case of searching for "_date of_"). Likewise, we restrict the results to the columns that will have results based on the `field` attribute of the aggregate. After we find the unique codes if the display values are unique, we can also join the aggregate frame to the actual code values.

Example:
```
# 6it [00:00, 9.34it/s]
# Retrieved 6 results
# 
# Retrieved 3017/3017 results
                   field        code                              system                        display  doc_count
0            code.coding     85337-4                    http://loinc.org       Estrogen Receptor Status     1048.0  
1            code.coding     85339-0                    http://loinc.org   Progesterone Receptor Status     1047.0
2            code.coding     49683-6                    http://loinc.org       HER2/neu receptor status      919.0
3  component.code.coding  TMB Status  http://lifeomic.com/fhir/biomarker                     TMB Status        3.0
```

### Usage ✍️ 

```python
phc.Observation.get_codes(display_query="date of")

# 9it [00:00, 14.80it/s]
# Retrieved 9 results
# 
# Retrieved 2332/2394 results
#
# =>           field            system     code                      display     doc_count  
# =>  0  code.coding  http://loinc.org  63931-0            Date of Diagnosis       1094.0  
# =>  1  code.coding  http://loinc.org  21975-8         Date of Last Contact       1094.0  
# =>  2  code.coding  http://loinc.org  21981-6  Date of Disease Progression        144.0  
```

Because we may end up retrieving a large number of records for the full code values, an additional `sample_size` can be passed to limit the full records passed. Here's what it looks like if some codes are not returned:

```python
phc.Observation.get_codes("status", sample_size=10)
# 6it [00:00, 10.72it/s]
# Retrieved 6 results
# 
# Retrieved 10/3017 results
# Records with missing system/code values were not retrieved.

# =>           field     code            system                       display     doc_count  
# =>  0  code.coding  85337-4  http://loinc.org      Estrogen Receptor Status        1048.0  
# =>  1  code.coding  85339-0  http://loinc.org  Progesterone Receptor Status        1047.0  
# =>  2          NaN      NaN               NaN      HER2/neu receptor status         919.0  
# =>  3          NaN      NaN               NaN                    TMB Status           3.0  
```