### PR TITLE
Add Cache for Paging APIs (e.g. GenomicTest)

### DIFF
--- a/phc/easy/omics/genomic_short_variant.py
+++ b/phc/easy/omics/genomic_short_variant.py
@@ -39,7 +39,7 @@ class GenomicShortVariant(PagingApiItem):
                 *expand_args.get("custom_columns", []),
                 *[
                     Frame.codeable_like_column_expander(k)
-                    for k in ["clinvar", "cosmic", "vcf"]
+                    for k in ["clinvar", "cosmic", "vcf", "ensemblCanon"]
                 ],
                 ("id", expand_id),
             ],

--- a/phc/easy/omics/genomic_test.py
+++ b/phc/easy/omics/genomic_test.py
@@ -1,11 +1,11 @@
 import inspect
-import pandas as pd
+from enum import Enum
 from typing import Optional
+
+import pandas as pd
 from phc.easy.auth import Auth
 from phc.easy.frame import Frame
 from phc.easy.paging_api_item import PagingApiItem, PagingApiOptions
-
-from enum import Enum
 
 
 class GenomicTestType(str, Enum):
@@ -49,7 +49,9 @@ class GenomicTest(PagingApiItem):
         return GenomicTestOptions
 
     @staticmethod
-    def transform_results(data_frame: pd.DataFrame, **expand_args):
+    def transform_results(
+        data_frame: pd.DataFrame, params: dict, **expand_args
+    ):
         args = {
             **expand_args,
             "code_columns": [
@@ -62,43 +64,54 @@ class GenomicTest(PagingApiItem):
                 Frame.codeable_like_column_expander("sourceFile"),
             ],
         }
+        df = Frame.expand(data_frame, **args)
 
-        return (
-            pd.concat(
-                data_frame.apply(
-                    lambda x: pd.DataFrame(
-                        [{"index": x.name, **s} for s in x.sets]
-                    ),
-                    axis=1,
-                ).values
+        if "sets" in df.columns:
+            df = (
+                pd.concat(
+                    data_frame.apply(
+                        lambda x: pd.DataFrame(
+                            [{"index": x.name, **s} for s in x.sets]
+                        ),
+                        axis=1,
+                    ).values
+                )
+                .join(df.drop(["sets"], axis=1), on="index", rsuffix=".test")
+                .drop(["index"], axis=1)
+                .reset_index(drop=True)
             )
-            .join(
-                Frame.expand(data_frame, **args).drop(["sets"], axis=1),
-                on="index",
-                rsuffix=".test",
-            )
-            .drop(["index"], axis=1)
-            .reset_index(drop=True)
-        )
+
+        test_type = params.get("type", None)
+
+        if test_type and len(df) > 0:
+            # TODO: Remove when API fixed
+
+            # NOTE: The API does not filter the returned sets because it is a
+            # nested structure. Since it's not a boatload of information, we opt
+            # to filter client-side for now.
+            return df[df.setType == test_type].reset_index(drop=True)
+
+        return df
 
     @classmethod
     def get_data_frame(
         cls,
         patient_id: Optional[str] = None,
-        status: Optional[GenomicTestStatus] = None,
+        status: Optional[GenomicTestStatus] = GenomicTestStatus.ACTIVE,
         test_type: Optional[GenomicTestType] = None,
         all_results: bool = False,
         auth_args: Auth = Auth.shared(),
         max_pages: Optional[int] = None,
         page_size: Optional[int] = None,
         log: bool = False,
+        ignore_cache: bool = False,
         **kw_args,
     ):
         """Execute a request for genomic tests
 
         ## Parameters
 
-        Query: `GenomicTestOptions`
+        Query: `phc.easy.omics.options.genomic_test.GenomicTestOptions`
 
         Execution: `phc.easy.query.Query.execute_paging_api`
 
@@ -109,15 +122,5 @@ class GenomicTest(PagingApiItem):
         df = super().get_data_frame(
             **kw_args, **cls._get_current_args(inspect.currentframe(), locals())
         )
-
-        if test_type and len(df) > 0:
-            # TODO: Remove when API fixed
-
-            # NOTE: The API does not filter the returned sets because it is a
-            # nested structure. Since it's not a boatload of information, we opt
-            # to filter client-side for now.
-            return df[
-                df.setType == getattr(test_type, "value", test_type)
-            ].reset_index(drop=True)
 
         return df

--- a/phc/easy/paging_api_item.py
+++ b/phc/easy/paging_api_item.py
@@ -82,11 +82,14 @@ class PagingApiItem:
             split_args.get("execute", {}),
         )
 
-        df = Query.execute_paging_api(
-            cls.resource_path(), params, **execute_options
-        )
+        def transform(df: pd.DataFrame):
+            if len(df) == 0:
+                return df
 
-        if len(df) > 0:
-            return cls.transform_results(df, **expand_args)
+            return cls.transform_results(df, params=params, **expand_args)
+
+        df = Query.execute_paging_api(
+            cls.resource_path(), params, **execute_options, transform=transform
+        )
 
         return df

--- a/phc/easy/util/__init__.py
+++ b/phc/easy/util/__init__.py
@@ -91,19 +91,6 @@ def with_progress(
     return func(None)
 
 
-def update_progress(progress: tqdm, n: int, description: str = ""):
-    """Update progress if available (Returns True to allow `and` chaining):
-
-        update_progress(None, 0, "hey") and my_return_value
-    """
-    if not progress:
-        return True
-
-    progress.set_description(description, refresh=False)
-    progress.update(n)
-    return True
-
-
 def add_prefixes(values: List[str], prefixes: List[str]):
     """Add prefix to each value if not already present"""
     if len(prefixes) == 0:

--- a/tests/test_genomic_test.py
+++ b/tests/test_genomic_test.py
@@ -1,0 +1,182 @@
+from unittest import mock
+from unittest.mock import ANY
+from math import nan
+
+import pandas as pd
+from phc.easy.omics.genomic_test import GenomicTest
+
+raw_df = pd.DataFrame(
+    # NOTE: Sample is taken and adapted from BRCA data set
+    [
+        {
+            "sets": [
+                {
+                    "status": "ACTIVE",
+                    "setType": "expression",
+                    "id": "1578b108-719e-4962-85f4-488c14aec26c",
+                    "fileId": "93f0bec1-a26b-42b5-9650-e368d748c3f8",
+                    "name": "Kapa400",
+                }
+            ],
+            "tasks": [],
+            "id": "1578b108-719e-4962-85f4-488c14aec26c",
+            "datasetId": "34c0fb25-bbde-4eb1-87ed-dd4c7a1ac013",
+            "name": "Kapa400",
+            "indexedDate": "2020-09-29T20:17:24.483Z",
+            "status": "ACTIVE",
+            "patientId": nan,
+            "referenceSetId": nan,
+            "patient": nan,
+        },
+        {
+            "sets": [
+                {
+                    "status": "ACTIVE",
+                    "sequenceType": "somatic",
+                    "setType": "shortVariant",
+                    "id": "defea4df-3fb5-4326-a0d9-576232a200f2",
+                    "fileId": "611a2b9a-17f8-4d98-9ef8-edefd02b9ee0",
+                    "sequenceId": "da852d20-0a33-4e24-b993-16b5fa545dc6",
+                    "name": "LO-C8-A138",
+                }
+            ],
+            "tasks": [],
+            "id": "da852d20-0a33-4e24-b993-16b5fa545dc6",
+            "datasetId": "34c0fb25-bbde-4eb1-87ed-dd4c7a1ac013",
+            "name": "LO-C8-A138",
+            "indexedDate": "2020-09-29T20:15:59.521Z",
+            "status": "ACTIVE",
+            "patientId": "b6c286c6-2755-419b-87d3-59c7feda9653",
+            "referenceSetId": "GRCh38",
+            "patient": {
+                "name": [
+                    {"text": "C8A138 LO", "given": ["C8A138"], "family": "LO"}
+                ],
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "ANON",
+                                    "system": "http://hl7.org/fhir/v2/0203",
+                                }
+                            ]
+                        },
+                        "value": "LO-C8-A138",
+                    }
+                ],
+                "id": "b6c286c6-2755-419b-87d3-59c7feda9653",
+                "resourceType": "Patient",
+            },
+        },
+        {
+            "sets": [
+                {
+                    "status": "ACTIVE",
+                    "sequenceType": "somatic",
+                    "setType": "shortVariant",
+                    "id": "2819306a-fbb8-4b32-a753-d2407e9c330a",
+                    "fileId": "0d9465db-4f05-4e15-9265-25f01eec42ec",
+                    "sequenceId": "f571ec0e-b097-48a1-9bcf-bc9d0bc2a1ee",
+                    "name": "LO-A7-A3RF",
+                }
+            ],
+            "tasks": [],
+            "id": "f571ec0e-b097-48a1-9bcf-bc9d0bc2a1ee",
+            "datasetId": "34c0fb25-bbde-4eb1-87ed-dd4c7a1ac013",
+            "name": "LO-A7-A3RF",
+            "indexedDate": "2020-09-29T20:15:59.392Z",
+            "status": "ACTIVE",
+            "patientId": "7451af3c-acc0-4d79-8429-6b8be96911d8",
+            "referenceSetId": "GRCh38",
+            "patient": {
+                "name": [
+                    {"text": "A7A3RF LO", "given": ["A7A3RF"], "family": "LO"}
+                ],
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "code": "ANON",
+                                    "system": "http://hl7.org/fhir/v2/0203",
+                                }
+                            ]
+                        },
+                        "value": "LO-A7-A3RF",
+                    }
+                ],
+                "id": "7451af3c-acc0-4d79-8429-6b8be96911d8",
+                "resourceType": "Patient",
+            },
+        },
+    ]
+)
+
+
+def test_idempotent():
+    frame = GenomicTest.transform_results(raw_df, params={})
+
+    second_frame = GenomicTest.transform_results(frame, params={})
+
+    assert frame.to_dict("records") == second_frame.to_dict("records")
+
+
+def test_filter_set_type():
+    frame = GenomicTest.transform_results(
+        raw_df, params={"type": "shortVariant"}
+    )
+
+    assert frame.setType.nunique() == 1
+    assert len(frame) == 2
+
+
+@mock.patch("phc.easy.query.Query.execute_paging_api")
+def test_get_data_frame(execute_paging_api):
+    "test a concrete subclass of pagingapiitem"
+    execute_paging_api.return_value = GenomicTest.transform_results(
+        raw_df, params={}
+    )
+
+    frame = GenomicTest.get_data_frame()
+
+    execute_paging_api.assert_called_once_with(
+        "genomics/projects/:project_id/tests",
+        {"patientId": None, "status": "ACTIVE", "type": None},
+        all_results=False,
+        auth_args=ANY,
+        max_pages=None,
+        page_size=None,
+        log=False,
+        ignore_cache=False,
+        transform=ANY,
+    )
+
+    print(frame.columns)
+
+    assert frame.columns.tolist() == [
+        "status",
+        "setType",
+        "id",
+        "fileId",
+        "name",
+        "sequenceType",
+        "sequenceId",
+        "tasks",
+        "id.test",
+        "datasetId",
+        "name.test",
+        "indexedDate",
+        "status.test",
+        "referenceSetId",
+        "patientId",
+        "patient.name_text",
+        "patient.name_given",
+        "patient.name_family",
+        "patient.type_coding_identifier_system__hl7.org/fhir/v2/0203__code",
+        "patient.type_coding_identifier_system__hl7.org/fhir/v2/0203__value",
+        "patient.id",
+        "patient.resourceType",
+    ]
+
+    assert frame.setType.unique().tolist() == ["expression", "shortVariant"]

--- a/tests/test_genomic_test.py
+++ b/tests/test_genomic_test.py
@@ -152,8 +152,6 @@ def test_get_data_frame(execute_paging_api):
         transform=ANY,
     )
 
-    print(frame.columns)
-
     assert frame.columns.tolist() == [
         "status",
         "setType",

--- a/tests/test_paging_api_item.py
+++ b/tests/test_paging_api_item.py
@@ -1,0 +1,18 @@
+from phc.easy.paging_api_item import split_kw_args
+
+
+def test_split_kw_args():
+    result = split_kw_args(
+        dict(
+            page_size=100,
+            max_pages=2,
+            test_type="shortVariant",
+            date_columns=[],
+        )
+    )
+
+    assert result == {
+        "execute": {"page_size": 100, "max_pages": 2},
+        "query": {"test_type": "shortVariant"},
+        "expand": {"date_columns": []},
+    }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,20 +1,29 @@
-from phc.easy.util.api_cache import APICache
+from phc.easy.util.api_cache import APICache, FHIR_DSL
 
 
-def test_filename_for_fhir_dsl_with_simple_statement():
-    filename = APICache.filename_for_fhir_dsl(
+def test_filename_for_genomics_api_call():
+    filename = APICache.filename_for_query(
+        {"path": "genomics/projects/dfkjkjsa-dkj2kd1-kjdkj-1dkj2/tests"}
+    )
+
+    assert filename == "genomics_projects_tests_04b0739f.csv"
+
+
+def test_filename_for_query_with_simple_statement():
+    filename = APICache.filename_for_query(
         {
             "type": "select",
             "columns": "*",
             "from": [{"table": "patient"}, {"table": "observation"}],
-        }
+        },
+        namespace=FHIR_DSL,
     )
 
     assert filename == "fhir_dsl_patient_observation_c57bdb78.csv"
 
 
-def test_filename_for_fhir_dsl_with_complex_statement():
-    filename = APICache.filename_for_fhir_dsl(
+def test_filename_for_query_with_complex_statement():
+    filename = APICache.filename_for_query(
         {
             "type": "select",
             "columns": [
@@ -41,14 +50,15 @@ def test_filename_for_fhir_dsl_with_complex_statement():
                     }
                 },
             },
-        }
+        },
+        namespace=FHIR_DSL,
     )
 
     assert filename == "fhir_dsl_goal_1col_where_08c25b4c.csv"
 
 
-def test_filename_for_fhir_dsl_with_aggregation():
-    filename = APICache.filename_for_fhir_dsl(
+def test_filename_for_query_with_aggregation():
+    filename = APICache.filename_for_query(
         {
             "type": "select",
             "columns": [
@@ -82,7 +92,8 @@ def test_filename_for_fhir_dsl_with_aggregation():
                     }
                 },
             },
-        }
+        },
+        namespace=FHIR_DSL,
     )
 
     assert filename == "fhir_dsl_goal_agg_where_58a8bb32.json"


### PR DESCRIPTION
Now, we can run the following (just like the FSS APIs):

```python
phc.GenomicTest.get_data_frame(status="ACTIVE", all_results=True)
# [CACHE] Loading from "/home/jovyan/Downloads/phc/api-cache/genomics_projects_tests_38a164d1.csv"
# ...
```

After an internal discussion with @atolivero and @jairav, we'd like to hide the concept of `variant_set_ids` from users of the SDK where possible. Essentially, we should be able to retrieve short variants (for example) and it just work™️ without having to join between `GenomicTest` and `GenomicShortVariant` with the `variant_set_id`. Therefore, it is essential that we cache the `GenomicTest` values since there will likely be many (e.g. 1004 active SV in the BRCA dataset).