### PR TITLE
Auto-retrieve GenomicTests for GenomicShortVariant

### DIFF
--- a/phc/easy/abstract/fhir_service_item.py
+++ b/phc/easy/abstract/fhir_service_item.py
@@ -36,7 +36,7 @@ class FhirServiceItem:
         )
 
     @staticmethod
-    def transform_results(data_frame: pd.DataFrame, **expand_args):
+    def transform_results(data_frame: pd.DataFrame, **_expand_args):
         "Transform data frame batch"
         return data_frame
 

--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -261,7 +261,7 @@ class Query:
                 params=params,
                 http_verb=http_verb,
                 callback=callback,
-                scroll=all_results or max_pages,
+                scroll=all_results or (max_pages is not None),
                 max_pages=max_pages,
                 page_size=page_size,
                 log=log,

--- a/phc/easy/query/api_paging.py
+++ b/phc/easy/query/api_paging.py
@@ -76,7 +76,6 @@ def recursive_paging_api_call(
         # next page exists
         or (response.data.get("links", {}).get("next") is None)
     )
-
     results = [] if callback else [*_prev_results, *current_results]
 
     # Sometimes the count doesn't match the results. We make it sync up if the

--- a/phc/easy/util/__init__.py
+++ b/phc/easy/util/__init__.py
@@ -1,6 +1,7 @@
 import math
 from functools import reduce, wraps
 from typing import Callable, List, Union
+from toolz import groupby
 
 import pandas as pd
 from funcy import lmapcat
@@ -162,3 +163,15 @@ def extract_codes(results: list, display: str, code_fields: List[str]):
                 codes.add(code)
 
     return pd.DataFrame(list(codes))
+
+
+def split_by(args: dict, left_keys: List[str]):
+    """Split into two dictionaries (left is whitelist and right is remaining)"""
+    result = {
+        k: dict(v)
+        for k, v in groupby(
+            lambda pair: pair[0] in left_keys, args.items()
+        ).items()
+    }
+
+    return (result.get(True, {}), result.get(False, {}))

--- a/phc/easy/util/api_cache.py
+++ b/phc/easy/util/api_cache.py
@@ -108,7 +108,8 @@ class APICache:
             )
 
             df = pd.DataFrame(batch)
-            writer.write(transform(df))
+            if len(df) != 0:
+                writer.write(transform(df))
 
             if is_finished and not os.path.exists(filename):
                 return pd.DataFrame()

--- a/phc/easy/util/batch.py
+++ b/phc/easy/util/batch.py
@@ -14,6 +14,9 @@ def batch_get_frame(
     max_batch_size: int,
     map_t: Callable[[List[str]], pd.DataFrame],
 ):
+    if len(ids) == 0:
+        return pd.DataFrame()
+
     chunked_ids = list(chunk(max_batch_size, ids))
 
     if len(chunked_ids) > 1 and tqdm is not None:

--- a/tests/test_easy_util.py
+++ b/tests/test_easy_util.py
@@ -6,6 +6,7 @@ from phc.easy.util import (
     join_underscore,
     prefix_dict_keys,
     without_keys,
+    split_by,
 )
 
 
@@ -100,6 +101,13 @@ def test_extract_codes():
         **samples[0]["code"]["coding"][0],
         "field": "code.coding",
     }
+
+
+def test_split_by():
+    set_a, set_b = split_by({"a": 1, "b": 2, "c": 3, "d": 4}, ["a", "c"])
+
+    assert list(set_a.keys()) == ["a", "c"]
+    assert list(set_b.keys()) == ["b", "d"]
 
 
 # defaultprop

--- a/tests/test_easy_util_batch_get.py
+++ b/tests/test_easy_util_batch_get.py
@@ -5,13 +5,14 @@ from phc.easy.util.batch import batch_get_frame
 from phc.easy.util import tqdm
 
 
-def test_batch_get_frame():
-    def transform(ids: List[str], total: int):
-        frame = pd.DataFrame({"id": ids})
-        frame["batch_size"] = len(ids)
-        frame["prev_total"] = total
-        return frame
+def transform(ids: List[str], total: int):
+    frame = pd.DataFrame({"id": ids})
+    frame["batch_size"] = len(ids)
+    frame["prev_total"] = total
+    return frame
 
+
+def test_batch_get_frame():
     assert_equals(
         batch_get_frame(["a", "b", "c"], 2, transform).to_dict("records"),
         [
@@ -20,3 +21,7 @@ def test_batch_get_frame():
             {"id": "c", "batch_size": 1, "prev_total": 2},
         ],
     )
+
+
+def test_empty_batch():
+    assert_equals(batch_get_frame([], 2, transform).to_dict("records"), [])

--- a/tests/test_genomic_short_variant.py
+++ b/tests/test_genomic_short_variant.py
@@ -32,16 +32,16 @@ def test_parse_id():
     assert "FASN" in frame.gene.values.tolist()
 
 
+@mock.patch("phc.easy.omics.genomic_test.GenomicTest.get_data_frame")
 @mock.patch("phc.easy.query.Query.execute_paging_api")
-def test_batches_of_variant_set_ids(execute_paging_api):
+def test_batches_of_variant_set_ids(execute_paging_api, test_get_data_frame):
     def get_variant_set_ids(index: int):
         return execute_paging_api.call_args_list[index][0][1][
             "variantSetIds"
         ].split(",")
 
-    execute_paging_api.return_value = pd.DataFrame(
-        {"id": [], "variant_set_id": []}
-    )
+    execute_paging_api.return_value = pd.DataFrame()
+    test_get_data_frame.return_value = pd.DataFrame()
 
     variant_set_ids = [str(uuid4()) for _ in range(250)]
 


### PR DESCRIPTION
Researchers shouldn't care about variant sets as a join table. This allows retrieving short variants directly.

```python
phc.GenomicShortVariant.get_data_frame(
    gene=["BRCA1"],
    clinvar_significance=["Pathogenic:like"],
    all_results=True
)
```

See #110 