### PR TITLE
Warn-only for out of bounds date in cache file

### DIFF
--- a/phc/easy/util/api_cache.py
+++ b/phc/easy/util/api_cache.py
@@ -148,5 +148,17 @@ class APICache:
             lambda c: np.count_nonzero(c.str.match(DATE_FORMAT_REGEX))
             > min_count
         )
-        df.loc[:, mask] = df.loc[:, mask].apply(pd.to_datetime)
+
+        try:
+            df.loc[:, mask] = df.loc[:, mask].apply(pd.to_datetime)
+        except pd.errors.OutOfBoundsDatetime as ex:
+            print(
+                "[WARNING]: OutOfBoundsDatetime encountered. Casting to NaT.",
+                ex,
+            )
+
+            df.loc[:, mask] = df.loc[:, mask].apply(
+                lambda c: pd.to_datetime(c, errors="coerce")
+            )
+
         return df

--- a/tests/test_api_cache.py
+++ b/tests/test_api_cache.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from nose.tools import assert_equals
 from phc.easy.util.api_cache import APICache, FHIR_DSL
 
@@ -108,3 +109,22 @@ def test_filename_for_query_with_aggregation():
     )
 
     assert filename == "fhir_dsl_goal_agg_where_58a8bb32.json"
+
+
+def test_reading_cache_file_with_invalid_date_does_not_raise():
+    sample_file = StringIO()
+    sample_file.write(
+        "\n".join(
+            [
+                "date,name",
+                "2020-01-01T00:00:00Z,A",
+                "2020-01-02T00:00:00Z,B",
+                "2020-01-03T00:00:00Z,C",
+                "2020-01-04T00:00:00Z,D",
+                "217-06-07T00:00:00Z,E",
+            ]
+        )
+    )
+    sample_file.seek(0)
+
+    APICache.read_csv(sample_file)


### PR DESCRIPTION
Closes #124 

Resolves an issue that Steve Bray found in testing while reading in genomic tests.