### PR TITLE
Add paging for projects and fix mismatched results

### DIFF
--- a/phc/easy/query/__init__.py
+++ b/phc/easy/query/__init__.py
@@ -175,6 +175,7 @@ class Query:
         log: bool = False,
         raw: bool = False,
         ignore_cache: bool = False,
+        show_progress: bool = True,
         progress: Optional[tqdm] = None,
     ):
         """Execute a API query that pages through results
@@ -228,7 +229,11 @@ class Query:
         auth = Auth(auth_args)
 
         params = clean_params(params)
-        path = path.replace(":project_id", auth.project_id)
+
+        # Do not pull project_id if not in URL (which throws error if project not selected)
+        if "project_id" in path:
+            path = path.replace(":project_id", auth.project_id)
+
         query = {"path": path, "method": http_verb, "params": params}
 
         if all_results and page_size is None:
@@ -255,7 +260,9 @@ class Query:
         )
 
         results = with_progress(
-            lambda: progress if progress is not None else tqdm(),
+            lambda: (progress if progress is not None else tqdm())
+            if show_progress
+            else None,
             lambda progress: recursive_paging_api_call(
                 path,
                 params=params,

--- a/phc/easy/query/api_paging.py
+++ b/phc/easy/query/api_paging.py
@@ -4,6 +4,9 @@ from phc.base_client import BaseClient
 from phc.easy.auth import Auth
 from phc.easy.util import tqdm
 
+from funcy import nth
+from urllib.parse import urlparse, parse_qs
+
 MAX_RESULT_SIZE = 999
 
 
@@ -13,6 +16,11 @@ def clean_params(params: dict):
         for k, v in params.items()
         if ((v is not None) and (not isinstance(v, str) or len(v) > 0))
     }
+
+
+def get_next_page_token(next_url: str):
+    "Parse next url and retrieve nextPageToken (or None)"
+    return nth(0, parse_qs(urlparse(next_url).query).get("nextPageToken", []))
 
 
 def recursive_paging_api_call(
@@ -119,6 +127,8 @@ def recursive_paging_api_call(
         scroll=scroll,
         _current_page=_current_page + 1,
         _prev_results=results,
-        _next_page_token=response.data.get("nextPageToken"),
+        _next_page_token=get_next_page_token(
+            response.data.get("links", {}).get("next", "")
+        ),
         _count=_count,
     )

--- a/phc/easy/util/__init__.py
+++ b/phc/easy/util/__init__.py
@@ -1,6 +1,6 @@
 import math
 from functools import reduce, wraps
-from typing import Callable, List, Union
+from typing import Callable, List, Union, Optional
 from toolz import groupby
 
 import pandas as pd
@@ -86,12 +86,14 @@ def defaultprop(fn):
 
 
 def with_progress(
-    init_progress: Callable[[], tqdm], func: Callable[[Union[None, tqdm]], None]
+    init_progress: Callable[[], Optional[tqdm]],
+    func: Callable[[Union[None, tqdm]], None],
 ):
     if _has_tqdm:
         progress = init_progress()
         result = func(progress)
-        progress.close()
+        if progress:
+            progress.close()
         return result
 
     return func(None)

--- a/tests/test_paging_api_item.py
+++ b/tests/test_paging_api_item.py
@@ -1,4 +1,7 @@
+from nose.tools import assert_equals
+
 from phc.easy.abstract.paging_api_item import split_kw_args
+from phc.easy.query.api_paging import get_next_page_token
 
 
 def test_split_kw_args():
@@ -16,3 +19,13 @@ def test_split_kw_args():
         "query": {"test_type": "shortVariant"},
         "expand": {"date_columns": []},
     }
+
+
+def test_parse_next_token_from_response_links():
+    next_token = "<my-next-token>"
+    url = f"/v1/projects?nextPageToken={next_token}&pageSize=100"
+
+    assert_equals(get_next_page_token(url), next_token)
+
+    # Handles case when no next token exists
+    assert_equals(get_next_page_token(""), None)


### PR DESCRIPTION
Closes #100 

This now uses the paging API standard that we use for the omics modules. Also, the operations now contain the account assignment explicitly so it shouldn't get confused. 🤞  I've tested it in dev/prod where I have a variety of projects across accounts.

Also, I needed to change how the next page token is grabbed since the `"/projects"` endpoint doesn't return the next token as a separate JSON item but includes it in the link.

The method supports a progress indicator but is off by default since it's not usually needed.

<img width="1401" alt="Screen Shot 2020-12-10 at 1 05 58 PM" src="https://user-images.githubusercontent.com/634167/101811739-73874280-3ae8-11eb-83c0-3e74ae40ebd9.png">i