### PR TITLE
Resolve open code scanning issues

### DIFF
--- a/phc/session.py
+++ b/phc/session.py
@@ -3,6 +3,7 @@
 import os
 import jwt
 import time
+from urllib.parse import urlparse
 
 
 class Session:
@@ -31,13 +32,15 @@ class Session:
         self.token = token
         self.refresh_token = refresh_token
         self.account = account
+
+        hostname = urlparse(self._get_decoded_token().get("iss", "")).hostname
         env = (
             "dev"
-            if "cognito-idp.us-east-1.amazonaws.com"
-            in self._get_decoded_token().get("iss")
-            or "api.dev.lifeomic.com" in self._get_decoded_token().get("iss")
+            if hostname
+            in ["cognito-idp.us-east-1.amazonaws.com", "api.dev.lifeomic.com"]
             else "us"
         )
+
         self.api_url = f"https://api.{env}.lifeomic.com/v1/"
         self.fhir_url = f"https://fhir.{env}.lifeomic.com/{account}/dstu3/"
         self.ga4gh_url = f"https://ga4gh.{env}.lifeomic.com/{account}/v1/"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 aiohttp>3.5.3
 nest_asyncio
 backoff==1.10.0
-pyjwt
+pyjwt==1.7.1
 pre-commit
 black==19.3b0
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>3.5.3
 backoff==1.10.0
 nest_asyncio
-pyjwt
+pyjwt==1.7.1
 pandas
 funcy
 lenses

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,32 @@
+import jwt
+from uuid import uuid4
+from nose.tools import assert_equals
+
+from phc.session import Session
+
+sample = {
+    "account": "test",
+    "username": "test_john.doe113@example.com",
+    "version": "1",
+    "token_use": "access",
+    "rnd": "blah==",
+    "iat": 1611587012,
+    "exp": 1623452314,
+    "iss": "https://api.dev.lifeomic.com/v1/api-keys",
+    "jti": str(uuid4()),
+}
+
+
+def test_session_env_dev_parsing():
+    token = jwt.encode(sample, "secret")
+    session = Session(token, account=sample["account"])
+    assert_equals(session.api_url, "https://api.dev.lifeomic.com/v1/")
+
+
+def test_session_env_prod_parsing():
+    token = jwt.encode(
+        {**sample, "iss": "https://api.us.lifeomic.com/v1/api-keys"}, "secret"
+    )
+
+    session = Session(token, account=sample["account"])
+    assert_equals(session.api_url, "https://api.us.lifeomic.com/v1/")


### PR DESCRIPTION
- Add strict matching of hostname to determine env
- Lock version of pyjwt (since API in version 2.0.x is slightly different)