### PR TITLE
Filter newlines from column names.

### DIFF
--- a/phc/util/csv_writer.py
+++ b/phc/util/csv_writer.py
@@ -1,4 +1,5 @@
 import os
+import re
 from io import StringIO
 import pandas as pd
 
@@ -17,6 +18,10 @@ class CSVWriter:
         """Write a data frame to an existing CSV file without loading the entire
         file into memory
         """
+
+        # Remove newlines from column names
+        frame.columns = [re.sub(r'[\t\n]', '', c) for c in frame.columns.tolist()]
+
         if not os.path.exists(self.filename):
             frame.to_csv(
                 self.filename, date_format="%Y-%m-%dT%H:%M:%S%z", index=False
@@ -44,10 +49,7 @@ class CSVWriter:
         self._finalize()
 
     def _columns(self):
-        with open(self.filename, "r") as f:
-            header = f.readline()
-
-        return pd.read_csv(StringIO(header)).columns.tolist()
+        return pd.read_csv(self.filename, nrows=0).columns.tolist()
 
     def _copy_to_backup_file_without_header(self):
         os.system(f"sed 1,1d {self.filename} > {self.bak_filename}")

--- a/tests/test_csv_writer.py
+++ b/tests/test_csv_writer.py
@@ -54,3 +54,47 @@ def test_writing_batches():
         ],
         is_nan(frame.values),
     ).all()
+
+
+def test_bad_column_names():
+    setup()
+    writer = CSVWriter("/tmp/sample.csv")
+
+    first_batch = pd.DataFrame(
+        [
+            {"first\n_name": "Laura", "last_name": "Lane"},
+            {"first\n_name": "Susie", "last_name": "Smith"},
+        ]
+    )
+
+    second_batch = pd.DataFrame(
+        [
+            {"first_name": "Jenny", "last\t_name": "Jones"},
+            {"last\t_name": "Motte", "date_of_birth": "03/07/1986"},
+        ]
+    )
+
+    writer.write(first_batch)
+    writer.write(second_batch)
+
+    frame = pd.read_csv("/tmp/sample.csv")
+
+    assert frame.columns.tolist() == [
+        "first_name",
+        "last_name",
+        "date_of_birth",
+    ]
+
+    # Cannot compare NaN - must use math.isnan()
+    is_nan = np.vectorize(lambda x: isinstance(x, float) and math.isnan(x))
+
+    assert np.logical_or(
+        frame.values
+        == [
+            ["Laura", "Lane", math.nan],
+            ["Susie", "Smith", math.nan],
+            ["Jenny", "Jones", math.nan],
+            [math.nan, "Motte", "03/07/1986"],
+        ],
+        is_nan(frame.values),
+    ).all()


### PR DESCRIPTION
The CSV cache breaks if there are newlines in the column names. This simply filters the newlines out of the column names which really don't need to be there.