### PR TITLE
Do proper check for tqdm progress to not error out

### DIFF
--- a/phc/easy/query/fhir_dsl.py
+++ b/phc/easy/query/fhir_dsl.py
@@ -108,7 +108,7 @@ def recursive_execute_fhir_dsl(
     if is_first_iteration and progress:
         progress.reset(actual_count)
 
-    if progress:
+    if progress is not None:
         progress.update(current_result_count)
 
     is_last_batch = (

--- a/phc/easy/util/__init__.py
+++ b/phc/easy/util/__init__.py
@@ -92,7 +92,7 @@ def with_progress(
     if _has_tqdm:
         progress = init_progress()
         result = func(progress)
-        if progress:
+        if progress is not None:
             progress.close()
         return result
 


### PR DESCRIPTION
This causes clients to error out when `tqdm` is installed and the progress doesn't already have a value greater than `0`.

I had squashed this bug in other places but missed some.