### PR TITLE
Fix docs build for release 0.22.0

### DIFF
--- a/phc/easy/abstract/fhir_service_item.py
+++ b/phc/easy/abstract/fhir_service_item.py
@@ -35,13 +35,20 @@ class FhirServiceItem:
 
     @ClassProperty
     @classmethod
-    def DSTU3(cls):
+    def DSTU3(cls) -> DSTU3:
         """Return a DSTU3 instance with the entity name configured
 
         Usage:
             phc.Patient.DSTU3.get(...)
         """
-        return DSTU3(snake_to_title_case(cls.table_name()))
+        try:
+            # Must wrap in try/except since docs try to access this on abstract classes
+            # where table_name() throws a ValueError
+            table_name = cls.table_name()
+        except Exception:
+            table_name = ""
+
+        return DSTU3(snake_to_title_case(table_name))
 
     @staticmethod
     def table_name() -> str:

--- a/phc/util/string_case.py
+++ b/phc/util/string_case.py
@@ -1,3 +1,6 @@
 def snake_to_title_case(snake_case: str):
     """Convert snake_case to TitleCase"""
+    if len(snake_case) == 0:
+        return snake_case
+
     return "".join([w[0].upper() + w[1:] for w in snake_case.split("_")])

--- a/tests/test_util_string_case.py
+++ b/tests/test_util_string_case.py
@@ -7,3 +7,4 @@ def test_snake_to_title_case():
         snake_to_title_case("document_reference"), "DocumentReference"
     )
     assert_equals(snake_to_title_case("patient"), "Patient")
+    assert_equals(snake_to_title_case(""), "")


### PR DESCRIPTION
Needed to change some code since the docs try to access an abstract class property that throws a `ValueError`.