### PR TITLE
[Quickfix] Allow adapter without token

### DIFF
--- a/phc/session.py
+++ b/phc/session.py
@@ -50,7 +50,7 @@ class Session:
         if not adapter:
             adapter = Adapter()
 
-        if not token or not account:
+        if adapter.should_refresh and (not token or not account):
             raise ValueError("Must provide a value for both token and account")
 
         self.token = token


### PR DESCRIPTION
If using a custom adapter, sometimes we don't want to require a token to be passed. If a fake token is passed, the current implementation requires it to at least be a valid JWT. 