### PR TITLE
Update to reflect changed response

### DIFF
--- a/phc/easy/dstu3.py
+++ b/phc/easy/dstu3.py
@@ -57,9 +57,9 @@ class DSTU3:
 
         response = client._fhir_call(
             f"{self.entity}/{record_id}", http_verb="PUT", json=data
-        ).data
+        )
 
-        if response == "OK":
+        if response.status_code == 200 or response.status_code == 201:
             return data
 
         raise ValueError(f"Unexpected response: {response}")
@@ -71,9 +71,9 @@ class DSTU3:
 
         response = client._fhir_call(
             f"{self.entity}", http_verb="POST", json=data
-        ).data
+        )
 
-        if response == "Created":
+        if response.status_code == 201:
             return True
 
         raise ValueError(f"Unexpected response: {response}")

--- a/phc/easy/dstu3.py
+++ b/phc/easy/dstu3.py
@@ -59,8 +59,8 @@ class DSTU3:
             f"{self.entity}/{record_id}", http_verb="PUT", json=data
         )
 
-        if response.status_code == 200 or response.status_code == 201:
-            return data
+        if 200 <= response.status_code < 300:
+            return response.data
 
         raise ValueError(f"Unexpected response: {response}")
 
@@ -73,8 +73,8 @@ class DSTU3:
             f"{self.entity}", http_verb="POST", json=data
         )
 
-        if response.status_code == 201:
-            return True
+        if 200 <= response.status_code < 300:
+            return response.data
 
         raise ValueError(f"Unexpected response: {response}")
 


### PR DESCRIPTION
The FHIR api used to just return the default `'CREATED'` string when creating a FHIR resource. Now it returns the created resource itself. The `DSTU3` class in the SDK is still expecting that `'CREATED'` string, so now it's throwing an error. This updates it to check status code instead.