### PR TITLE
PHC-5060: removing docs for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install virtualenv
-          make test doc
+          make test
           ./publish.sh
-      - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: doc/build/phc


### PR DESCRIPTION
Docs is broken with these updates.  After looking for a couple of hours, I had no joy in making them work.  I disabled doc generation and publishing.  So the existing docs should still be out there and valid.  Once I get this out to fix triaxia, I'll come back and figure out the docs.  it's been over a year since pdoc3 was updated so maybe the answer is moving to something more maintained, sphinx looked like a possibility.,