### PR TITLE
PHC-5060: changing release pythong

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10.12",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Utilities",
     ],
 )


### PR DESCRIPTION
Trying this again.  The github action build needed the `.12` modifier, so I updated them all to that, but it looks like from the publish that pypi won't accept that level of granularity.  I hope at least, can't really test publishing.