### PR TITLE
build: supports more python versions

### DIFF
--- a/.github/workflows/pr-branch-build.yml
+++ b/.github/workflows/pr-branch-build.yml
@@ -1,20 +1,27 @@
 name: PR Branch Build and Test
 
 on:
-  push:
-    branches-ignore:
-      - master
+  # Triggers the workflow on pull request events but only for the master branch
+  pull_request:
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Build and Test
-      run: |
-        pip install virtualenv
-        make test package
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Build and Test
+        run: |
+          pip install virtualenv
+          make test package

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Utilities",
     ],
 )


### PR DESCRIPTION
Supports more up-to-date python versions.

In current production environment, it uses python 3.10 from the latest data science notebook images so it should cover at least python 3.10.

I'd suggest:

* drop support for python 3.7-3.8 if not used
* add support for python 3.11 if developer uses it for local dev/test