### PR TITLE
build: fixes python-version in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install poetry
         run: pipx install poetry==1.5.1
       - name: Publish to PyPi


### PR DESCRIPTION
Supports #193 

this is for fixing broken release: https://github.com/lifeomic/phc-sdk-py/actions/runs/5718536447/job/15494563678#step:3:11

> Error: The version '3.1' with architecture 'x64' was not found for Ubuntu 22.04.