### PR TITLE
build: fixes release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,15 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pipx install poetry==1.5.1
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: "poetry"
-
-      - name: Install poetry
-        run: pipx install poetry==1.5.1
 
       - run: poetry install
       - run: |


### PR DESCRIPTION
I thought about why installing poetry before setup python (w/ poetry cache) and now I remembered why I did this for PR build: 

https://github.com/lifeomic/phc-sdk-py/blob/a6a554aced6b0181dc883d8c2e647459f9185214/.github/workflows/pr-branch-build.yml#L19-L26

The source of solution: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages