### PR TITLE
build: fixes release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Install poetry
         run: pipx install poetry==1.5.1
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8" # pdoc works under this version
           cache: "poetry"
 
       - run: poetry install


### PR DESCRIPTION
the release process must be under python 3.8/3.9 where `pdoc` works. see https://github.com/lifeomic/phc-sdk-py/pull/190

this is the No.5 attempt to fix the release process.