### PR TITLE
Suppress tqdm warning

### DIFF
--- a/phc/easy/util/__init__.py
+++ b/phc/easy/util/__init__.py
@@ -7,7 +7,7 @@ from funcy import lmapcat
 from toolz import groupby
 
 try:
-    from tqdm.autonotebook import tqdm
+    from tqdm.auto import tqdm
 except ImportError:
     _has_tqdm = False
     tqdm = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phc"
-version = "0.33.1"
+version = "0.33.2"
 description = "Python SDK for the LifeOmic platform"
 authors = ["LifeOmic <development@lifeomic.com>"]
 license = "MIT"


### PR DESCRIPTION
The following warning pops up when doing a `import phc.easy`:
```md
TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)
```
Per the tqdm docs:
<img width="801" alt="image" src="https://github.com/lifeomic/phc-sdk-py/assets/40117693/d0e90820-db80-47cc-ba33-4c9556e5bd7c">

